### PR TITLE
Integration of Round5

### DIFF
--- a/crypto_kem/r5nd/ref/LICENSE
+++ b/crypto_kem/r5nd/ref/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2018, Koninklijke Philips N.V. and Markku-Juhani O. Saarinen
+
+All rights reserved. A copyright license for redistribution and use in source 
+and binary forms, with or without modification, is hereby granted for
+non-commercial, experimental, research, public review and evaluation purposes, 
+provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution. If you wish to use 
+  this software commercially, kindly contact info.licensing@philips.com to 
+  obtain a commercial license.
+ 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/crypto_kem/r5nd/ref/Makefile
+++ b/crypto_kem/r5nd/ref/Makefile
@@ -1,0 +1,33 @@
+CC     = arm-none-eabi-gcc
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+AR     = arm-none-eabi-gcc-ar
+
+CC_HOST = gcc
+CFLAGS_HOST = -Wall -Wextra -O3
+AR_HOST = gcc-ar
+
+HEADERS = api.h encrypt.h params.h ringmul.h xecc.h xof_hash.h
+SOURCES = encrypt.c kem_cca.c kem_cpa.c ringmul.c ringmul_cm.c xecc.c xof_hash.c
+OBJECTS = kem_cpa.o kem_cca.o ringmul.o ringmul_cm.o encrypt.o xecc.o xof_hash.o
+
+OBJECTS_HOST = $(patsubst %.o,%_host.o,$(OBJECTS))
+
+libpqm4.a: $(OBJECTS)
+	$(AR) rcs $@ $(OBJECTS)
+
+libpqhost.a: $(OBJECTS_HOST)
+	$(AR_HOST) rcs $@ $(OBJECTS_HOST)
+
+%_host.o: %.c $(HEADERS)
+	$(CC_HOST) -I$(INCPATH) $(CFLAGS_HOST) -c -o $@ $<
+
+%.o: %.c $(HEADERS)
+	$(CC) -I$(INCPATH) $(CFLAGS) -c -o $@ $<
+
+.PHONY: clean
+.INTERMEDIATE: $(OBJECTS) $(OBJECTS_HOST)
+
+clean:
+	-rm -f libpqhost.a
+	-rm -f libpqm4.a
+	-rm -f *.o

--- a/crypto_kem/r5nd/ref/README.md
+++ b/crypto_kem/r5nd/ref/README.md
@@ -1,0 +1,128 @@
+## r5nd\_tiny
+
+A small and fast C language implementation of the Round5 quantum resistant
+public key encryption algorithm ring variants.
+
+---
+
+
+This code originally developed for embedded targets but it has excellent 
+performance on higher-end systems as well. This is the implementation 
+reported in the paper [*"Shorter Messages and Faster Post-Quantum Encryption 
+with Round5 on Cortex M"*](https://round5.org/doc/r5m4text.pdf), which is
+also [IACR ePrint 2018/723](https://eprint.iacr.org/2018/723).
+
+Even though that paper focuses on the NIST Category 3 versions 
+R5ND\_3KEM and R5ND\_3PKE, this implementation actually supports all six 
+ring variants. 
+
+| **Parameter** | **R5ND\_1KEM** | **R5ND\_3KEM** | **R5ND\_5KEM** | **R5ND\_1PKE** | **R5ND\_3PKE** | **R5ND\_5PKE** |
+| ------------- | :------------: | :------------: | :------------: | :------------: | :------------: | :------------: |
+| Shared Secret | 128 bit        | 192 bit        | 256 bit        | 128 bit        | 192 bit        | 256 bit        |
+| Public key    | 538 B          | 780 B          | 1050 B         | 562 B          | 810 B          | 1140 B         |
+| Secret key    | 16 B           | 24 B           | 32 B           | 594 B          | 858 B          | 1204 B         |
+| Ciphertext    | 632 B          | 904 B          | 1207 B         | 672 B          | 1032 B         | 1376 B         |
+| Failure rate  | 2<sup>-76</sup> | 2<sup>-75</sup> | 2<sup>-64</sup> | 2<sup>-129</sup> | 2<sup>-128</sup> | 2<sup>-129</sup> |
+| PQ Security	| 2<sup>117</sup> | 2<sup>176</sup> | 2<sup>242</sup> | 2<sup>120</sup> | 2<sup>181</sup> | 2<sup>246</sup> |
+| Classical 	| 2<sup>128</sup> | 2<sup>193</sup> | 2<sup>257</sup> | 2<sup>128</sup> | 2<sup>193</sup> | 2<sup>256</sup> |
+| Security Category  | CPA, NIST 1    | CPA, NIST 3    | CPA, NIST 5    | CCA, NIST 1    | CCA, NIST 3    | CCA, NIST 5    |
+
+For Round5 security arguments and discussion about non-ring versions,
+see the main paper [*"Round5: Compact and Fast Post-Quantum Public-Key 
+Encryption"*](https://round5.org/doc/round5paper.pdf).
+
+A Data Encapsulation Mechanism (DEM) is not included. You can use the 
+implementations for public key encryption with an AEAD mode such as GCM or 
+SIV  -- just derive the KEY (and IV) from the shared secret. This will add 
+16 bytes (the authentication tag) to your message length, in addition to the 
+"Ciphertext" number given in the table.
+
+Note that Round5 also has non-ring variants. This is an early technology 
+demonstrator, not a reference implementation. The current version is 
+unlikely to be entirely compatible with the final Round5 specification.
+
+
+### Comparison on Cortex M4
+
+Round5 is currently the fastest post-quantum encryption algorithm in all
+NIST security classes where it is implemented. It also has the shortest 
+public keys and messages of any lattice-based NIST PQC candidates. The 
+Isogeny-based proposal SIKE requires 15-35% less bytes for key establishment 
+but is thousands of times slower, making it completely impractical for 
+embedded devices.
+
+Here is a simple engineering and security comparison for key establishment use 
+case on Cortex M4. All of the compared algorithms are at NIST Category 3.
+
+* **Xfer:** Total data transferred (public key + ciphertext), in bytes.
+* **Time:** Time required for KeyGen() + Encaps() +  Decaps() on Cortex-M4 at 24 MHz. 
+* **Code:** Size of implementation in bytes, excluding hash function and other common parts. 
+* **Failure:** Decryption failure bound.
+* **Post-Quantum:** Claimed quantum complexity.
+* **Classical** Claimed classical complexity.
+
+| **Algorithm** | **Xfer** | **Time** | **Code** | **Failure** | **Post-Quantum** | **Classical** |
+| ------------- | :------: | :------: | :------: | :------: | :-----: | :------: |
+| R5ND\_3KEM    | 1684 B   | 0.124 s  | 4464 B   | 2<sup>-75</sup>	| 2<sup>176</sup> | 2<sup>193</sup>	|
+| R5ND\_3PKE    | 1842 B   | 0.169 s  | 5232 B   | 2<sup>-129</sup>	| 2<sup>181</sup> | 2<sup>193</sup>	| 
+| Saber         | 2080 B   | 0.172 s  | ?        | 2<sup>-136</sup>	| 2<sup>180</sup> | 2<sup>198</sup>	| 
+| Kyber-768     | 2240 B   | 0.210 s  | 7016  B  | 2<sup>-142</sup>	| 2<sup>161</sup> | 2<sup>178</sup>	|
+| sntrup4591761 | 2265 B   | 8.718 s  | 71024 B  | 0                | -               | 2<sup>248</sup> |
+| NTRU-HRSS17   | 2416 B   | 7.814 s  | 11956 B  | 0                | 2<sup>123</sup> | 2<sup>136</sup> |
+| NewHope1024-CCA | 4032 B | 0.264 s  | 12912 B  | 2<sup>-216</sup>	| 2<sup>233</sup> | -	| 
+| SIKEp751      | 1160 B   | 685.9 s  | 19112 B  | 0                | 2<sup>124</sup> | 2<sup>186</sup> |
+
+
+### Code Structure
+
+Most things are controlled by compiler macros (defines) -- you can set
+these in `Makefile`, in environment variable `R5INC`, or statically, e.g., 
+at top of `api.h`.
+
+Choose exactly one of these (e.g. compile with `make R5INC=-DR5ND_3KEM`):
+
+* `R5ND_1KEM`: CPA, NIST security category 1, parameter set
+* `R5ND_3KEM`: CPA, NIST security category 3, parameter set
+* `R5ND_5KEM`: CPA, NIST security category 5, parameter set
+* `R5ND_1PKE`: CCA, NIST security category 1, parameter set
+* `R5ND_3PKE`: CCA, NIST security category 3, parameter set
+* `R5ND_5PKE`: CCA, NIST security category 5, parameter set
+
+There is one additional flag:
+
+* `CM_CACHE`: Enable cache timing attack countermeasures (drops speed to
+about half). This is not relevant for cacheless embedded systems.
+
+The flags affect call structure, which is as follows:
+```
+       External Caller          Uses NIST API (api.h)
+         /         \
+     kem_cca.c   kem_cpa.c      Depending on NOFO_CPA (set by KEM/PKE)
+         \         /
+          encrypt.c             Basic CPA functionality
+         /         \
+    ringmul.c  ringmul_cm.c     Depending on CM_CACHE
+```
+
+The make process produces a benchmarking executable `r5test`.
+
+
+### Testing
+
+You can run `./bench_all.sh` which will compile and benchmark all six variants. 
+The result is written to `bench.txt`. It will also compare `CHK`-prefixed 
+test vector checksums to known answers in `chk_kat_data.txt`.
+
+
+### Big Small Print
+
+See the `LICENCE` file for licence details. 
+
+**ABSOLUTELY NO WARRANTY.**
+The code was mainly written by Markku-Juhani O. Saarinen <mjos@mjos.fi>, 
+who was also the main author of the paper. Bug reports can be directed to him.
+
+**TECHNOLOGY DEMONSTRATOR -- EXPERIMENTAL RESEARCH CODE.**
+This is not an official implementation of anything, or intended for
+production use. All parameters and algorithm details are subject to change.
+

--- a/crypto_kem/r5nd/ref/api.h
+++ b/crypto_kem/r5nd/ref/api.h
@@ -1,0 +1,41 @@
+//  api.h
+//  2018-06-30  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+#ifndef _API_H_
+#define _API_H_
+
+/* define default parameter set */
+
+#define R5ND_3KEM
+
+#include "params.h"
+
+
+/*
+    This is the API defined by NIST for PQC KEMs.
+
+    Public key:     unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+    Secret key:     unsigned char sk[CRYPTO_SECRETKEYBYTES];
+    Ciphertext:     unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
+    Shared secret:  unsigned char ss[CRYPTO_BYTES];
+
+    The functions always return 0. In case of decryption error the shared
+    secrets from crypto_kem_enc() and crypto_kem_dec() simply won't match.
+*/
+
+// Key generation: (pk, sk) = KeyGen()
+
+int crypto_kem_keypair(unsigned char *pk, unsigned char *sk);
+
+// Encapsulate: (ct, ss) = Encaps(pk)
+
+int crypto_kem_enc(unsigned char *ct, unsigned char *ss, 
+                   const unsigned char *pk);
+
+// Decapsulate: ss = Decaps(ct, sk)
+
+int crypto_kem_dec(unsigned char *ss, 
+                   const unsigned char *ct, const unsigned char *sk);
+
+#endif /* _API_H_ */
+

--- a/crypto_kem/r5nd/ref/encrypt.c
+++ b/crypto_kem/r5nd/ref/encrypt.c
@@ -1,0 +1,198 @@
+// encrypt.c
+// 2018-06-17  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+#include <string.h>
+
+#include "api.h"
+#include "encrypt.h"
+#include "xof_hash.h"
+#include "randombytes.h"
+#include "xecc.h"
+#include "ringmul.h"
+
+// flip a vector of 16-byte values (in case big endian)
+
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+static void flip16vec(uint16_t *v, size_t len)
+{
+    uint16_t x;
+    size_t i;
+
+    for (i = 0; i < len; i++) {
+        x = v[i];
+        x = ((x << 8) ^ (x >> 8)) & 0xFFFF;
+        v[i] = x;
+    }
+}
+#endif
+
+// compress q->p and pack nd values of p bits
+
+static void compress_q_pack_ndp(uint8_t *pv, const modq_t *vq)
+{
+#if (PARAMS_P_BITS == 8)
+    size_t i;
+
+    for (i = 0; i < PARAMS_ND; i++) {
+        pv[i] = ((vq[i] + (1 << (PARAMS_Q_BITS - PARAMS_P_BITS - 1))) >>
+                (PARAMS_Q_BITS - PARAMS_P_BITS)) & ((1 << PARAMS_P_BITS) - 1);
+    }
+#else
+    size_t i, j;
+    modp_t t;
+
+    memset(pv, 0, PARAMS_NDP_SIZE);
+    j = 0;
+    for (i = 0; i < PARAMS_ND; i++) {
+        t = ((vq[i] + (1 << (PARAMS_Q_BITS - PARAMS_P_BITS - 1))) >>
+            (PARAMS_Q_BITS - PARAMS_P_BITS)) & ((1 << PARAMS_P_BITS) - 1);
+        pv[j >> 3] |= t << (j & 7);         // pack p bits
+        if ((j & 7) + PARAMS_P_BITS > 8) {
+            pv[(j >> 3) + 1] |= t >> (8 - (j & 7));
+        }
+        j += PARAMS_P_BITS;
+    }
+#endif
+}
+
+// unpack a vector
+
+static void unpack_ndp(modp_t *vp, const uint8_t *pv)
+{
+#if (PARAMS_P_BITS == 8)
+    memcpy(vp, pv, PARAMS_ND);
+#else
+    size_t i, j;
+    modp_t t;
+
+    j = 0;
+    for (i = 0; i < PARAMS_ND; i++) {
+        t = pv[j >> 3] >> (j & 7);          // unpack p bits
+        if ((j & 7) + PARAMS_P_BITS > 8) {
+            t |= ((modp_t) pv[(j >> 3) + 1]) << (8 - (j & 7));
+        }
+        vp[i] = t;
+        j += PARAMS_P_BITS;
+    }
+#endif
+}
+
+// generate a keypair (sigma, B)
+
+int generate_keypair(uint8_t *pk, uint8_t *sk)
+{
+    modq_t A[PARAMS_ND];
+    modq_t B[PARAMS_ND + PARAMS_MUL_PAD];
+
+    uint16_t S_idx[PARAMS_H / 2][2];
+
+    randombytes(pk, PARAMS_SS_SIZE);        // sigma = seed of A
+    XOF_hash(A, pk, PARAMS_SS_SIZE, PARAMS_ND * sizeof(modq_t));
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+    flip16vec(A, PARAMS_ND);
+#endif
+    randombytes(sk, PARAMS_SK_SIZE);        // secret key -- Random S
+    create_spter_idx(S_idx, sk, PARAMS_SK_SIZE);
+
+    ringmul_q(B, A, S_idx);                 // B = A * S
+
+    // Compress B q_bits -> p_bits, pk = sigma | B
+    compress_q_pack_ndp(pk + PARAMS_SS_SIZE, B);
+
+    return 0;
+}
+
+int encrypt_rho(uint8_t *ct, const uint8_t *m,
+   const uint8_t *rho, const uint8_t *pk)
+{
+    size_t i, j;
+    modq_t A[PARAMS_ND];
+    uint16_t R_idx[PARAMS_H / 2][2];
+    modq_t U[PARAMS_ND + PARAMS_MUL_PAD];
+    modp_t B[PARAMS_ND];
+    modp_t X[PARAMS_MU + PARAMS_MUL_PAD];
+    uint8_t mm[PARAMS_SS_SIZE + PARAMS_XE_SIZE];
+    uint8_t t;
+
+    // unpack public key
+    unpack_ndp(B, pk + PARAMS_SS_SIZE);
+
+    // A from sigma
+    XOF_hash(A, pk, PARAMS_SS_SIZE, PARAMS_ND * sizeof(*A));
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    flip16vec(A, PARAMS_ND);
+#endif
+
+    memcpy(mm, m, PARAMS_SS_SIZE);          // add error correction code
+    memset(mm + PARAMS_SS_SIZE, 0, PARAMS_XE_SIZE);
+    xe_compute(mm);
+
+    // Create R
+    create_spter_idx(R_idx, rho, PARAMS_SS_SIZE);
+
+    ringmul_q(U, A, R_idx);                 // U = A * R  (mod q)
+    ringmul_p(X, B, R_idx);                 // X = B * R  (mod p)
+
+    compress_q_pack_ndp(ct, U);             // ct = U | v
+
+    memset(ct + PARAMS_NDP_SIZE, 0, PARAMS_MUT_SIZE);
+    j = 8 * PARAMS_NDP_SIZE;
+
+    for (i = 0; i < PARAMS_MU; i++) {       // compute, pack v
+        // compress p->t
+        t = ((X[i] + (1 << (PARAMS_P_BITS - PARAMS_T_BITS - 1))) >>
+               (PARAMS_P_BITS - PARAMS_T_BITS));
+        // add message
+        t = (t + (((mm[i >> 3] >> (i & 7)) & 1) <<
+               (PARAMS_T_BITS - 1))) & ((1 << PARAMS_T_BITS) - 1);
+
+        ct[j >> 3] |= t << (j & 7);         // pack t bits
+        if ((j & 7) + PARAMS_T_BITS > 8) {
+            ct[(j >> 3) + 1] |= t >> (8 - (j & 7));
+        }
+        j += PARAMS_T_BITS;
+    }
+
+    return 0;
+}
+
+int decrypt(uint8_t *m, const uint8_t *ct, const uint8_t *sk)
+{
+    size_t i, j;
+    uint16_t S_idx[PARAMS_H / 2][2];
+    modp_t U[PARAMS_ND];
+    modp_t v[PARAMS_MU];
+    modp_t t, tmp[PARAMS_MU + PARAMS_MUL_PAD];
+    uint8_t mm[PARAMS_SS_SIZE + PARAMS_XE_SIZE];
+
+    create_spter_idx(S_idx, sk, PARAMS_SK_SIZE);
+
+    unpack_ndp(U, ct);                      // ct = U | v
+
+    j = 8 * PARAMS_NDP_SIZE;
+    for (i = 0; i < PARAMS_MU; i++) {
+        t = ct[j >> 3] >> (j & 7);          // unpack t bits
+        if ((j & 7) + PARAMS_T_BITS > 8) {
+            t |= ct[(j >> 3) + 1] << (8 - (j & 7));
+        }
+        v[i] = t & ((1 << PARAMS_T_BITS) - 1);
+        j += PARAMS_T_BITS;
+    }
+
+    ringmul_p(tmp, U, S_idx);               // v - U * S (mod p)
+    for (i = 0; i < PARAMS_MU; i++)
+        tmp[i] = (v[i] << (PARAMS_P_BITS - PARAMS_T_BITS)) - tmp[i];
+
+    memset(mm, 0, sizeof(mm));
+    for (i = 0; i < PARAMS_MU; ++i) {       // reconstruct message
+        t = ((tmp[i] + (1 << (PARAMS_P_BITS - 1 - 1))) >>
+               (PARAMS_P_BITS - 1)) & 1;
+        mm[i >> 3] |= t << (i & 7);
+    }
+
+    xe_fixerr(mm);                          // apply error correction
+    memcpy(m, mm, PARAMS_SS_SIZE);
+
+    return 0;
+}
+

--- a/crypto_kem/r5nd/ref/encrypt.h
+++ b/crypto_kem/r5nd/ref/encrypt.h
@@ -1,0 +1,19 @@
+//  encrypt.h
+//  2018-06-17  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+#ifndef _ENCRYPT_H_
+#define _ENCRYPT_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+int encrypt_rho(uint8_t *c, const uint8_t *m,
+    const uint8_t *rho, const uint8_t *pk);
+
+int generate_keypair(uint8_t *pk, uint8_t *sk);
+
+int encrypt(uint8_t *c, const uint8_t *m, const uint8_t *pk);
+
+int decrypt(uint8_t *m, const uint8_t *c, const uint8_t *sk);
+
+#endif /* _ENCRYPT_H_ */

--- a/crypto_kem/r5nd/ref/kem_cca.c
+++ b/crypto_kem/r5nd/ref/kem_cca.c
@@ -1,0 +1,137 @@
+//  kem_cca.c
+//  2018-06-17  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+//  CCA Versions of KEM functionality
+
+#include "api.h"
+
+#ifndef NOFO_CPA
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "encrypt.h"
+#include "xof_hash.h"
+#include "randombytes.h"
+
+// CCA-KEM KeyGen()
+
+int crypto_kem_keypair(uint8_t *pk, uint8_t *sk) 
+{
+    uint8_t z[PARAMS_SS_SIZE];
+
+    /* Generate the base key pair */
+    generate_keypair(pk, sk);
+
+    /* Append z and pk to sk */
+    randombytes(z, PARAMS_SS_SIZE);
+    memcpy(sk + PARAMS_SK_SIZE, z, PARAMS_SS_SIZE);
+    memcpy(sk + PARAMS_SK_SIZE + PARAMS_SS_SIZE, pk, PARAMS_PK_SIZE);
+
+    return 0;
+}
+
+// CCA-KEM Encaps()
+
+int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) 
+{
+    uint8_t hash_in[PARAMS_SS_SIZE + PARAMS_CT_SIZE + PARAMS_SS_SIZE];
+    uint8_t m[PARAMS_SS_SIZE];
+    uint8_t l_g_rho[3][PARAMS_SS_SIZE];
+
+    randombytes(m, PARAMS_SS_SIZE);     // generate random m
+
+    memcpy(hash_in, m, PARAMS_SS_SIZE); // G: (l | g | rho) = h(m | pk);
+    memcpy(hash_in + PARAMS_SS_SIZE, pk, PARAMS_PK_SIZE);
+    XOF_hash(l_g_rho, hash_in, PARAMS_SS_SIZE + PARAMS_PK_SIZE,
+            3 * PARAMS_SS_SIZE);
+
+    /* Encrypt  */
+    encrypt_rho(ct, m, l_g_rho[2], pk); // m: c = (U,v)
+
+    /* Append g: c = (U,v,g) */
+    memcpy(ct + PARAMS_CT_SIZE, l_g_rho[1], PARAMS_SS_SIZE);
+
+    /* K = H(l, c) */
+    memcpy(hash_in, l_g_rho[0], PARAMS_SS_SIZE);
+    memcpy(hash_in + PARAMS_SS_SIZE, 
+        ct, PARAMS_CT_SIZE + PARAMS_SS_SIZE);
+    XOF_hash(ss, hash_in, 
+        PARAMS_SS_SIZE + PARAMS_CT_SIZE + PARAMS_SS_SIZE, 
+        PARAMS_SS_SIZE);
+
+    return 0;
+}
+
+// constant time comparison; return nonzero if not equal
+
+static uint8_t ct_memcmp(const void *a, const void *b, size_t len)
+{
+    const uint8_t *a8 = (const uint8_t *) a;
+    const uint8_t *b8 = (const uint8_t *) b;
+    uint8_t flag = 0;
+    size_t i;
+ 
+    for (i = 0; i < len; i++) {
+        flag |= a8[i] ^ b8[i];
+    }
+ 
+    return flag;
+}
+
+// conditional move; overwrite d with a if flag is nonzero
+
+static void ct_cmov(void *d, const void * a, uint8_t flag, size_t len)
+{
+    uint8_t *d8 = (uint8_t *) d;
+    const uint8_t *a8 = (const uint8_t *) a;
+    size_t i;
+
+    flag = -((flag | -flag) >> 7);          // 0x00 or 0xFF
+
+    for (i = 0; i < len; i++) {
+        d8[i] ^= flag & (d8[i] ^ a8[i]);
+    }
+}
+
+// CCA-KEM Decaps()
+
+int crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) 
+{
+    uint8_t hash_in[PARAMS_SS_SIZE + PARAMS_CT_SIZE + PARAMS_SS_SIZE];
+    uint8_t m[PARAMS_SS_SIZE];
+    uint8_t l_g_rho[3][PARAMS_SS_SIZE];
+    uint8_t c[PARAMS_CT_SIZE + PARAMS_SS_SIZE];
+    uint8_t fail;
+ 
+    decrypt(m, ct, sk);                 // decrypt m'
+
+    memcpy(hash_in, m, PARAMS_SS_SIZE);
+    memcpy(hash_in + PARAMS_SS_SIZE,    // (L | g | rho) = h(m | pk)
+        sk + PARAMS_SK_SIZE + PARAMS_SS_SIZE, PARAMS_PK_SIZE);
+    XOF_hash(l_g_rho, hash_in, PARAMS_SS_SIZE + PARAMS_PK_SIZE,
+            3 * PARAMS_SS_SIZE);
+
+    encrypt_rho(c, m, l_g_rho[2],       // Encrypt m: c' = (U',v')
+        sk + PARAMS_SK_SIZE + PARAMS_SS_SIZE); // pk
+
+    // c' = (U',v',g') 
+    memcpy(c + PARAMS_CT_SIZE, l_g_rho[1], PARAMS_SS_SIZE);
+
+    // K = H(l', c')
+    memcpy(hash_in, l_g_rho[0], PARAMS_SS_SIZE);
+    // verification ok ?
+    fail = ct_memcmp(ct, c, PARAMS_CT_SIZE + PARAMS_SS_SIZE);
+    // K = H(z, c')
+    ct_cmov(hash_in, sk + PARAMS_SK_SIZE, fail, PARAMS_SS_SIZE);
+    
+    memcpy(hash_in + PARAMS_SS_SIZE, c, PARAMS_CT_SIZE + PARAMS_SS_SIZE);
+    XOF_hash(ss, hash_in, 
+        PARAMS_SS_SIZE + PARAMS_CT_SIZE + PARAMS_SS_SIZE, 
+        PARAMS_SS_SIZE);
+
+    return 0;
+}
+
+#endif /* NOFO_CPA */

--- a/crypto_kem/r5nd/ref/kem_cpa.c
+++ b/crypto_kem/r5nd/ref/kem_cpa.c
@@ -1,0 +1,68 @@
+//  kem_cpa.c
+//  2018-06-17  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+//  CPA Versions of KEM functionality
+
+#include "api.h"
+
+#ifdef NOFO_CPA
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "encrypt.h"
+#include "xof_hash.h"
+#include "randombytes.h"
+
+// CPA-KEM KeyGen()
+
+int crypto_kem_keypair(uint8_t *pk, uint8_t *sk) 
+{
+    generate_keypair(pk, sk);
+
+    return 0;
+}
+
+// CPA-KEM Encaps()
+
+int crypto_kem_enc(uint8_t *ct, uint8_t *ss, const uint8_t *pk) 
+{
+    uint8_t hash_input[PARAMS_SS_SIZE + CRYPTO_CIPHERTEXTBYTES];
+    uint8_t m[PARAMS_SS_SIZE];
+    uint8_t rho[PARAMS_SS_SIZE];
+
+    /* Generate a random m */
+    randombytes(m, PARAMS_SS_SIZE);   
+    randombytes(rho, PARAMS_SS_SIZE);
+    encrypt_rho(ct, m, rho, pk);
+
+    /* K = H(m, c) */
+    memcpy(hash_input, m, PARAMS_SS_SIZE);
+    memcpy(hash_input + PARAMS_SS_SIZE, ct, CRYPTO_CIPHERTEXTBYTES);
+    XOF_hash(ss, hash_input, PARAMS_SS_SIZE + CRYPTO_CIPHERTEXTBYTES,
+        PARAMS_SS_SIZE);
+
+    return 0;
+}
+
+// CPA-KEM Decaps()
+
+int crypto_kem_dec(uint8_t *ss, const uint8_t *ct, const uint8_t *sk) 
+{
+    uint8_t hash_input[PARAMS_SS_SIZE + CRYPTO_CIPHERTEXTBYTES];
+    uint8_t m[PARAMS_SS_SIZE];
+
+    /* Decrypt m */
+    decrypt(m, ct, sk);
+
+    /* K = H(m, c) */
+    memcpy(hash_input, m, PARAMS_SS_SIZE);
+    memcpy(hash_input + PARAMS_SS_SIZE, ct, CRYPTO_CIPHERTEXTBYTES);
+    XOF_hash(ss, hash_input, PARAMS_SS_SIZE + CRYPTO_CIPHERTEXTBYTES, 
+        PARAMS_SS_SIZE);
+
+    return 0;
+}
+
+#endif /* NOFO_CPA */
+

--- a/crypto_kem/r5nd/ref/params.h
+++ b/crypto_kem/r5nd/ref/params.h
@@ -1,0 +1,143 @@
+//  params.h
+//  2018-06-26  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+#ifndef _PARAMS_H_
+#define _PARAMS_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+// parameter sets defined here
+
+#ifdef R5ND_1KEM
+#define NOFO_CPA
+#define PARAMS_ND       522
+#define PARAMS_H        208
+#define PARAMS_Q_BITS   14
+#define PARAMS_P_BITS   8
+#define PARAMS_T_BITS   4
+#define PARAMS_SS_SIZE  16
+#define PARAMS_XE       91
+#define CRYPTO_ALGNAME  "Round5 R5ND_1KEM"
+#endif
+
+#ifdef R5ND_3KEM
+#define NOFO_CPA
+#define PARAMS_ND       756
+#define PARAMS_H        242
+#define PARAMS_Q_BITS   15
+#define PARAMS_P_BITS   8
+#define PARAMS_T_BITS   4
+#define PARAMS_SS_SIZE  24
+#define PARAMS_XE       103
+#define CRYPTO_ALGNAME  "Round5 R5ND_3KEM"
+#endif
+
+#ifdef R5ND_5KEM
+#define NOFO_CPA
+#define PARAMS_ND       1018
+#define PARAMS_H        254
+#define PARAMS_Q_BITS   15
+#define PARAMS_P_BITS   8
+#define PARAMS_T_BITS   4
+#define PARAMS_SS_SIZE  32
+#define PARAMS_XE       121
+#define CRYPTO_ALGNAME  "Round5 R5ND_5KEM"
+#endif
+
+#ifdef R5ND_1PKE
+#define PARAMS_ND       546
+#define PARAMS_H        158
+#define PARAMS_Q_BITS   16
+#define PARAMS_P_BITS   8
+#define PARAMS_T_BITS   4
+#define PARAMS_SS_SIZE  16
+#define PARAMS_XE       91
+#define CRYPTO_ALGNAME  "Round5 R5ND_1PKE"
+#endif
+
+#ifdef R5ND_3PKE
+#define PARAMS_ND       786
+#define PARAMS_H        204
+#define PARAMS_Q_BITS   16
+#define PARAMS_P_BITS   8
+#define PARAMS_T_BITS   6
+#define PARAMS_SS_SIZE  24
+#define PARAMS_XE       103
+#define CRYPTO_ALGNAME  "Round5 R5ND_3PKE"
+#endif
+
+#ifdef R5ND_5PKE
+#define PARAMS_ND       1108
+#define PARAMS_H        198
+#define PARAMS_Q_BITS   16
+#define PARAMS_P_BITS   8
+#define PARAMS_T_BITS   5
+#define PARAMS_SS_SIZE  32
+#define PARAMS_XE       121
+#define CRYPTO_ALGNAME  "Round5 R5ND_5PKE"
+#endif
+
+#ifndef CRYPTO_ALGNAME
+#error You must define one of: R5ND_1KEM R5ND_1PKE R5ND_3KEM R5ND_3PKE R5ND_5KEM R5ND_5PKE.
+#endif
+
+// appropriate types
+typedef uint16_t modq_t;
+#if (PARAMS_P_BITS <= 8)
+typedef uint8_t modp_t;
+#else
+typedef uint16_t modp_t;
+#endif
+typedef uint8_t modt_t;
+
+// padding space for unrolled loop
+#ifdef CM_CACHE
+#define PARAMS_MUL_PAD  1
+#else
+// This is the best unroll parameter for 3PKE .. not all
+#define PARAMS_MUL_PAD  7
+#endif /* CM_CACHE */
+
+// derive internal parameters
+#ifndef BITS_TO_BYTES
+#define BITS_TO_BYTES(x) (((x) + 7) / 8)
+#endif
+
+#define PARAMS_Q        (1 << PARAMS_Q_BITS)
+#define PARAMS_Q_MASK   (PARAMS_Q - 1)
+#define PARAMS_P_MASK   ((1 << PARAMS_P_BITS) - 1)
+#define PARAMS_MU       (8 * PARAMS_SS_SIZE + PARAMS_XE)
+#define PARAMS_XE_SIZE  BITS_TO_BYTES(PARAMS_XE)
+#define PARAMS_NDP_SIZE BITS_TO_BYTES(PARAMS_ND * PARAMS_P_BITS)
+#define PARAMS_MUT_SIZE BITS_TO_BYTES(PARAMS_MU * PARAMS_T_BITS)
+#define PARAMS_RS_DIV   (0x10000 / PARAMS_ND)
+#define PARAMS_RS_LIM   (PARAMS_ND * PARAMS_RS_DIV)
+
+#define PARAMS_PK_SIZE  (PARAMS_SS_SIZE + PARAMS_NDP_SIZE)
+#define PARAMS_SK_SIZE  PARAMS_SS_SIZE
+#define PARAMS_CT_SIZE  (PARAMS_NDP_SIZE + PARAMS_MUT_SIZE)
+
+// Derive the NIST parameters
+
+// NOFO_CPA = no Fujisaki-Okamoto -> CPA
+#ifdef NOFO_CPA
+
+// CPA Variant
+#define CRYPTO_SECRETKEYBYTES  PARAMS_SK_SIZE
+#define CRYPTO_PUBLICKEYBYTES  PARAMS_PK_SIZE
+#define CRYPTO_BYTES           PARAMS_SS_SIZE
+#define CRYPTO_CIPHERTEXTBYTES PARAMS_CT_SIZE
+
+#else /* NOFO_CPA */
+
+// CCA Variant
+#define CRYPTO_SECRETKEYBYTES  (PARAMS_SK_SIZE + PARAMS_SS_SIZE + PARAMS_PK_SIZE)
+#define CRYPTO_PUBLICKEYBYTES  PARAMS_PK_SIZE
+#define CRYPTO_BYTES           PARAMS_SS_SIZE
+#define CRYPTO_CIPHERTEXTBYTES (PARAMS_CT_SIZE + PARAMS_SS_SIZE)
+
+#endif /* NOFO_CPA */
+
+#endif /* _PARAMS_H_ */
+

--- a/crypto_kem/r5nd/ref/ringmul.c
+++ b/crypto_kem/r5nd/ref/ringmul.c
@@ -1,0 +1,174 @@
+//  ringmul.c
+//  2018-06-26  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+//  Fast ring arithmetic (without cache countermeasures)
+
+#ifndef CM_CACHE
+
+#include <string.h>
+
+#include "api.h"
+#include "ringmul.h"
+#include "xof_hash.h"
+
+// create a sparse ternary vector from a seed
+
+void create_spter_idx(uint16_t idx[PARAMS_H / 2][2],
+                        const uint8_t *seed, const size_t seed_size)
+{
+    size_t i;
+    uint16_t x;
+    uint8_t v[PARAMS_ND];
+    XOF_ctx xof;
+
+    memset(v, 0, sizeof(v));
+    XOF_absorb(&xof, seed, seed_size);      // initialize with seed
+
+    for (i = 0; i < PARAMS_H; i++) {
+        do {
+            do {
+                XOF_squeeze(&xof, &x, 2);
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+                x = ((x << 8) ^ (x >> 8)) & 0xFFFF;
+#endif
+            } while (x >= PARAMS_RS_LIM);
+            x /= PARAMS_RS_DIV;
+        } while (v[x]);
+        idx[i >> 1][i & 1] = x;             // addition / subtract index
+        v[x] = 1;
+    }
+}
+
+// multiplication mod q, result length n
+
+void ringmul_q(modq_t d[PARAMS_ND + PARAMS_MUL_PAD],
+    const modq_t a[PARAMS_ND], const uint16_t idx[PARAMS_H / 2][2])
+{
+    size_t i, j;
+    modq_t t;
+    modq_t *qt, *rt;
+    modq_t p[2 * (PARAMS_ND + 1) + PARAMS_MUL_PAD];
+
+    p[0] = -a[0];
+    for (i = 1; i < PARAMS_ND; i++) {       // "lift" -- multiply by (x - 1)
+        p[i] = a[i - 1] - a[i];
+    }
+    p[PARAMS_ND] = a[PARAMS_ND - 1];
+
+    memcpy(p  + (PARAMS_ND + 1), p,         // duplicate
+        (PARAMS_ND + 1) * sizeof(modq_t));
+
+    memset(d, 0, PARAMS_ND * sizeof(modq_t));
+
+    for (i = 0; i < PARAMS_H / 2; i++) {
+        qt = &p[idx[i][0]];
+        rt = &p[idx[i][1]];
+
+        for (j = 0; j < PARAMS_ND;) {       // unrolled!
+            d[j] += qt[j] - rt[j];
+            j++;
+#if (PARAMS_MUL_PAD >= 2)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 3)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 4)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 5)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 6)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 7)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 8)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+        }
+    }
+    t = 0;
+    for (i = 0; i < PARAMS_ND; i++) {   // "unlift"
+        t -= d[i];
+        d[i] = t;
+    }
+}
+
+// multiplication mod p, result length mu
+
+void ringmul_p(modp_t d[PARAMS_MU + PARAMS_MUL_PAD],
+    const modp_t a[PARAMS_ND], const uint16_t idx[PARAMS_H / 2][2])
+{
+    int i, j;
+    modp_t t;
+    modp_t *pt, *qt, *rt;
+    modp_t p[PARAMS_MU + 1 + (PARAMS_ND + 1) + PARAMS_MUL_PAD];
+
+    pt = &p[PARAMS_MU];
+    pt[PARAMS_ND + 1] = -a[0];
+    for (i = 1; i < PARAMS_ND; i++) {       // "lift" -- multiply by (x - 1)
+        pt[i] = a[i - 1] - a[i];
+    }
+    pt[PARAMS_ND] = a[PARAMS_ND - 1];
+    memcpy(p, p + (PARAMS_ND + 1),          // duplicate at beginning
+        (PARAMS_MU + 1) * sizeof(modp_t));
+
+    memset(d, 0, PARAMS_MU * sizeof(modp_t));
+
+    for (i = 0; i < PARAMS_H / 2; i++) {
+        qt = &p[idx[i][0]];
+        rt = &p[idx[i][1]];
+
+        for (j = 0; j < PARAMS_MU;) {       // unrolled!
+            d[j] += qt[j] - rt[j];
+            j++;
+#if (PARAMS_MUL_PAD >= 2)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 3)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 4)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 5)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 6)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 7)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+#if (PARAMS_MUL_PAD >= 8)
+            d[j] += qt[j] - rt[j];
+            j++;
+#endif
+        }
+    }
+
+    t = 0;
+    for (i = PARAMS_MU - 1; i >= 0; i--) {  // "unlift"
+        t += d[i];
+        d[i] = t;
+    }
+}
+
+#endif /* CM_CACHE */
+

--- a/crypto_kem/r5nd/ref/ringmul.h
+++ b/crypto_kem/r5nd/ref/ringmul.h
@@ -1,0 +1,21 @@
+// ringmul.h
+// 2018-06-26  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+#ifndef _RINGMUL_H_
+#define _RINGMUL_H_
+
+#include "api.h"
+
+// create a sparse ternary vector from a seed
+void create_spter_idx(uint16_t idx[PARAMS_H / 2][2],
+    const uint8_t *seed, const size_t seed_size);
+
+// multiplication mod q, result length n
+void ringmul_q(modq_t d[PARAMS_ND + PARAMS_MUL_PAD],
+    const modq_t a[PARAMS_ND], const uint16_t idx[PARAMS_H / 2][2]);
+
+// multiplication mod p, result length mu
+void ringmul_p(modp_t d[PARAMS_MU + PARAMS_MUL_PAD],
+    const modp_t a[PARAMS_ND], const uint16_t idx[PARAMS_H / 2][2]);
+
+#endif /* _RINGMUL_H_ */

--- a/crypto_kem/r5nd/ref/ringmul_cm.c
+++ b/crypto_kem/r5nd/ref/ringmul_cm.c
@@ -1,0 +1,163 @@
+//  ringmul_cm.c
+//  2018-06-26  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+//  This version includes cache timing attack countermeasures.
+
+#ifdef CM_CACHE
+
+#include <string.h>
+
+#include "api.h"
+#include "ringmul.h"
+#include "xof_hash.h"
+
+#define PROBEVEC64  ((PARAMS_ND + 63) / 64)
+
+// Cache-resistant "occupancy probe". Tests and "occupies" a single bit at x.
+// Return value zero (false) indicates the the slot was originally empty.
+
+static int probe_cm(uint64_t *v, int x)
+{
+    int i;
+    uint64_t a, b, c, y, z;
+
+    // construct the selector
+    y = (1llu) << (x & 0x3F);               // low bits of index
+
+#if 0
+    z = (1llu) << (x >> 6);                 // high bits of index
+#else
+    z = 1llu;                               // no constant-time 64-bit shift
+    a = -((x >> 6) & 1);
+    z = ((z << 1) & a) ^ (z & ~a);
+    a = -((x >> 7) & 1);
+    z = ((z << 2) & a) ^ (z & ~a);
+    a = -((x >> 8) & 1);
+    z = ((z << 4) & a) ^ (z & ~a);
+    a = -((x >> 9) & 1);
+    z = ((z << 8) & a) ^ (z & ~a);
+    a = -((x >> 10) & 1);                   // can handle up to n=d=2048
+    z = ((z << 16) & a) ^ (z & ~a);
+#endif
+
+    c = 0;
+    for (i = 0; i < PROBEVEC64; i++) {      // always scan through all
+        a = v[i];
+        b = a | (y & (-(z & 1)));           // set bit
+        c |= a ^ b;                         // mask for change
+        v[i] = b;
+        z >>= 1;
+    }
+
+    // final comparison doesn't need to be constant time
+    return c == 0;                          // return true if was occupied
+}
+
+// create a sparse ternary vector from a seed
+
+void create_spter_idx(uint16_t idx[PARAMS_H / 2][2],
+                        const uint8_t *seed, const size_t seed_size)
+{
+    size_t i;
+    uint16_t x;
+    uint64_t v[PROBEVEC64];
+    XOF_ctx xof;
+
+    memset(v, 0, sizeof(v));
+    XOF_absorb(&xof, seed, seed_size);      // initialize with seed
+
+    for (i = 0; i < PARAMS_H; i++) {
+        do {
+            do {
+                XOF_squeeze(&xof, &x, 2);
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+                x = ((x << 8) ^ (x >> 8)) & 0xFFFF;
+#endif
+            } while (x >= PARAMS_RS_LIM);
+            x /= PARAMS_RS_DIV;
+        } while (probe_cm(v, x));
+        idx[i >> 1][i & 1] = x;             // addition / subtract index
+    }
+}
+
+// multiplication mod q, result length n
+
+void ringmul_q(modq_t d[PARAMS_ND + PARAMS_MUL_PAD],
+    const modq_t a[PARAMS_ND], const uint16_t idx[PARAMS_H / 2][2])
+{
+    size_t i, j, k;
+    modq_t t, p[PARAMS_ND + 1 + PARAMS_MUL_PAD];
+
+    p[0] = -a[0];
+    for (i = 1; i < PARAMS_ND; i++) {       // "lift" -- multiply by (x - 1)
+        p[i] = a[i - 1] - a[i];
+    }
+    p[PARAMS_ND] = a[PARAMS_ND - 1];
+
+    memset(d, 0, PARAMS_ND * sizeof(modq_t));
+
+    for (i = 0; i < PARAMS_H / 2; i++) {
+
+        k = idx[i][0];                      // modified to always scan
+        for (j = 0; k <= PARAMS_ND;)        // the same ranges
+            d[j++] += p[k++];
+        for (k = 0; j < PARAMS_ND;)
+            d[j++] += p[k++];
+
+        k = idx[i][1];                      // negative coefficient
+        for (j = 0; k <= PARAMS_ND;)
+            d[j++] -= p[k++];
+        for (k = 0; j < PARAMS_ND;)
+            d[j++] -= p[k++];
+    }
+    t = 0;
+    for (i = 0; i < PARAMS_ND; i++) {       // "unlift"
+        t -= d[i];
+        d[i] = t;
+    }
+}
+
+// multiplication mod p, result length mu
+
+void ringmul_p(modp_t d[PARAMS_MU + PARAMS_MUL_PAD],
+    const modp_t a[PARAMS_ND], const uint16_t idx[PARAMS_H / 2][2])
+{
+    size_t i, j, k;
+    modp_t t, p[PARAMS_ND + 1 + PARAMS_MUL_PAD],
+        e[PARAMS_ND + PARAMS_MUL_PAD];
+
+    p[0] = -a[0];
+    for (i = 1; i < PARAMS_ND; i++) {       // "lift" -- multiply by (x - 1)
+        p[i] = a[i - 1] - a[i];
+    }
+    p[PARAMS_ND] = a[PARAMS_ND - 1];
+
+    memset(e, 0, PARAMS_ND * sizeof(modp_t));
+
+    for (i = 0; i < PARAMS_H / 2; i++) {
+
+        k = idx[i][0];                      // modified to always scan
+        for (j = 0; k <= PARAMS_ND;)        // the same ranges
+            e[j++] += p[k++];
+        for (k = 0; j < PARAMS_ND;)
+            e[j++] += p[k++];
+
+        k = idx[i][1];                      // negative coefficient
+        for (j = 0; k <= PARAMS_ND;)
+            e[j++] -= p[k++];
+        for (k = 0; j < PARAMS_ND;)
+            e[j++] -= p[k++];
+    }
+
+    t = 0;
+    for (i = 0; i < PARAMS_ND; i++) {       // "unlift"
+        t -= e[i];
+        e[i] = t;
+    }
+
+    // copy the last part to caller
+    memcpy(d, &e[PARAMS_ND - PARAMS_MU], PARAMS_MU * sizeof(modp_t));
+}
+
+#endif /* CM_CACHE */
+

--- a/crypto_kem/r5nd/ref/xecc.c
+++ b/crypto_kem/r5nd/ref/xecc.c
@@ -1,0 +1,302 @@
+//  xecc.c
+//  2018-06-15  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+//  Error Correction Codes
+
+#include "api.h"
+#include "xecc.h"
+
+#define ROTR32_REGN(r, n) { r = (r >> (32 % n)) | (r << (n - (32 % n))); }
+#define FOLD_MASK(r, x, n) { r = (r ^ x ^ (x >> n)) & ((1 << n) - 1); }
+#define FOLD2_MASK(r, x, n) \
+    { r = (r ^ x ^ (x >> n) ^ (x >> (2 * n))) & ((1 << n) - 1); }
+
+#define MASK_UNFOLD(r, n) { r &= ((1 << n) - 1); r ^= r << n; }
+#define MASK_UNFOLD2(r, n) { r &= ((1 << n) - 1); \
+    r ^= (r << n) ^ (r << (2 * n)); }
+#define ROTL32_REGN(r, n) { r = (r << (32 % n)) | (r >> (n - (32 % n))); }
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define ENDIAN32(x) (x)
+#else
+#define ENDIAN32(x) ((((x) & 0xFF000000) >> 24u) |  \
+                     (((x) & 0x00FF0000) >> 8u)  |  \
+                     (((x) & 0x0000FF00) << 8u)  |  \
+                     (((x) & 0x000000FF) << 24u))
+#endif
+
+// == Error Correction Code XE3-91 =======================================
+
+#if ((PARAMS_SS_SIZE == 16) && (PARAMS_XE_SIZE == 12))
+
+void xe_compute(void *block)
+{
+    int i;
+    uint32_t x;
+    uint32_t r11, r13, r15, r16, r17, r19;
+    uint32_t *v = (uint32_t *) block;
+
+    r11 = r13 = r15 = r16 = r17 = r19 = 0;
+
+    for (i = 3; i >= 0; i--) {          // six word payload
+
+        if (i < 3) {
+            ROTR32_REGN(r11, 11);
+            ROTR32_REGN(r13, 13);
+            ROTR32_REGN(r15, 15);
+            ROTR32_REGN(r17, 17);
+            ROTR32_REGN(r19, 19);
+        }
+
+        x = ENDIAN32(v[i]);             // load a word
+        FOLD2_MASK(r11, x, 11);
+        FOLD2_MASK(r13, x, 13);
+        FOLD2_MASK(r15, x, 15);
+        r16 ^= x;
+        FOLD_MASK(r17, x, 17);
+        FOLD_MASK(r19, x, 19);
+    }
+    r16 = (r16 ^ (r16 >> 16)) & 0xFFFF;
+
+    // Codeword:    r13 r19 r15 r17 r16 r11
+    // Bit offset:  0   13  32  47  64  80  91
+    x = r13 ^ (r19 << 13);
+    v[ 4] ^= ENDIAN32(x);
+    x = r15 ^ (r17 << 15);
+    v[ 5] ^= ENDIAN32(x);
+    x = r16 ^ (r11 << 16);
+    v[ 6] ^= ENDIAN32(x);
+}
+
+void xe_fixerr(void *block)
+{
+    int i, j;
+    uint32_t x;
+    uint32_t r11, r13, r15, r16, r17, r19;
+    uint32_t *v = (uint32_t *) block;
+
+    xe_compute(block);
+
+    // Codeword:    r13 r19 r15 r17 r16 r11
+    // Bit offset:  0   13  32  47  64  80  91
+    r13 = ENDIAN32(v[4]);
+    r19 = r13 >> 13;
+    r15 = ENDIAN32(v[5]);
+    r17 = r15 >> 15;
+    r16 = ENDIAN32(v[6]);
+    r11 = r16 >> 16;
+
+    MASK_UNFOLD2(r11, 11);
+    MASK_UNFOLD2(r13, 13);
+    MASK_UNFOLD2(r15, 15);
+    MASK_UNFOLD(r16, 16);
+    MASK_UNFOLD(r17, 17);
+    MASK_UNFOLD(r19, 19);
+
+    for (i = 0; i < 4; i++) {
+        x = ENDIAN32(v[i]);
+        for (j = 0; j < 4; j++) {
+            x ^= ((0x44444444 + (((r13 >> j) & 0x11111111) +
+                ((r15 >> j) & 0x11111111) + ((r16 >> j) & 0x11111111) +
+                ((r17 >> j) & 0x11111111) + ((r19 >> j) & 0x11111111) +
+                ((r11 >> j) & 0x11111111))) & 0x88888888) >> (3 - j);
+        }
+        v[i] = ENDIAN32(x);
+
+        if (i < 3) {
+            ROTL32_REGN(r11, 11);
+            ROTL32_REGN(r13, 13);
+            ROTL32_REGN(r15, 15);
+            ROTL32_REGN(r17, 17);
+            ROTL32_REGN(r19, 19);
+        }
+    }
+}
+
+#endif
+
+// == Error Correction Code XE3-103 =======================================
+
+#if ((PARAMS_SS_SIZE == 24) && (PARAMS_XE_SIZE == 13))
+
+void xe_compute(void *block)
+{
+    int i;
+    uint32_t x;
+    uint32_t r13, r15, r16, r17, r19, r23;
+    uint32_t *v = (uint32_t *) block;
+
+    r13 = r15 = r16 = r17 = r19 = r23 = 0;
+
+    for (i = 5; i >= 0; i--) {          // six word payload
+
+        if (i < 5) {
+            ROTR32_REGN(r13, 13);
+            ROTR32_REGN(r15, 15);
+            ROTR32_REGN(r17, 17);
+            ROTR32_REGN(r19, 19);
+            ROTR32_REGN(r23, 23);
+        }
+
+        x = ENDIAN32(v[i]);             // load a word
+        FOLD2_MASK(r13, x, 13);
+        FOLD2_MASK(r15, x, 15);
+        r16 ^= x;
+        FOLD_MASK(r17, x, 17);
+        FOLD_MASK(r19, x, 19);
+        FOLD_MASK(r23, x, 23);
+    }
+    r16 = (r16 ^ (r16 >> 16)) & 0xFFFF;
+
+    // Codeword:    r13 r19 r15 r17 r16 r23
+    // Bit offset:  0   13  32  47  64  80  103
+    x = r13 ^ (r19 << 13);
+    v[ 6] ^= ENDIAN32(x);
+    x = r15 ^ (r17 << 15);
+    v[ 7] ^= ENDIAN32(x); 
+    x = r16 ^ (r23 << 16);
+    v[ 8] ^= ENDIAN32(x); 
+    *((uint8_t *) &v[9]) ^= r23 >> 16;  //  7 bits
+}
+
+void xe_fixerr(void *block)
+{
+    int i, j;
+    uint32_t x;
+    uint32_t r13, r15, r16, r17, r19, r23;
+    uint32_t *v = (uint32_t *) block;
+
+    xe_compute(block);
+
+    // Codeword:    r13 r19 r15 r17 r16 r23
+    // Bit offset:  0   13  32  47  64  80  103
+    r13 = ENDIAN32(v[6]);
+    r19 = r13 >> 13;
+    r15 = ENDIAN32(v[7]);
+    r17 = r15 >> 15;
+    r16 = ENDIAN32(v[8]);
+    r23 = (r16 >> 16) ^ (((uint32_t) *((uint8_t *) &v[9])) << 16);
+
+    MASK_UNFOLD2(r13, 13);
+    MASK_UNFOLD2(r15, 15);
+    MASK_UNFOLD(r16, 16);
+    MASK_UNFOLD(r17, 17);
+    MASK_UNFOLD(r19, 19);
+    MASK_UNFOLD(r23, 23);
+
+    for (i = 0; i < 6; i++) {
+        x = ENDIAN32(v[i]);
+        for (j = 0; j < 4; j++) {
+            x ^= ((0x44444444 + (((r13 >> j) & 0x11111111) +
+                ((r15 >> j) & 0x11111111) + ((r16 >> j) & 0x11111111) +
+                ((r17 >> j) & 0x11111111) + ((r19 >> j) & 0x11111111) +
+                ((r23 >> j) & 0x11111111))) & 0x88888888) >> (3 - j);
+        }
+        v[i] = ENDIAN32(x);
+
+        if (i < 5) {
+            ROTL32_REGN(r13, 13);
+            ROTL32_REGN(r15, 15);
+            ROTL32_REGN(r17, 17);
+            ROTL32_REGN(r19, 19);
+            ROTL32_REGN(r23, 23);
+        }
+    }
+}
+
+#endif
+
+// == Error Correction Code XE3-121 =======================================
+
+#if ((PARAMS_SS_SIZE == 32) && (PARAMS_XE_SIZE == 16))
+
+void xe_compute(void *block)
+{
+    int i;
+    uint32_t x;
+    uint32_t r16, r17, r19, r21, r23, r25;
+    uint32_t *v = (uint32_t *) block;
+
+    r16 = r17 = r19 = r21 = r23 = r25 = 0;
+
+    for (i = 7; i >= 0; i--) {          // six word payload
+
+        if (i < 7) {
+            ROTR32_REGN(r17, 17);
+            ROTR32_REGN(r19, 19);
+            ROTR32_REGN(r21, 21);
+            ROTR32_REGN(r23, 23);
+            ROTR32_REGN(r25, 25);
+        }
+
+        x = ENDIAN32(v[i]);             // load a word
+        r16 ^= x;
+        FOLD_MASK(r17, x, 17);
+        FOLD_MASK(r19, x, 19);
+        FOLD_MASK(r21, x, 21);
+        FOLD_MASK(r23, x, 23);
+        FOLD_MASK(r25, x, 25);
+    }
+    r16 = (r16 ^ (r16 >> 16)) & 0xFFFF;
+
+    // Codeword:    r16 r17 r19 r21 r23 r25
+    // Bit offset:  0   16  33  52  73  96  121
+    x = r16 ^ (r17 << 16);
+    v[ 8] ^= ENDIAN32(x);
+    x = (r17 >> 16) ^ (r19 << 1) ^ (r21 << 20);
+    v[ 9] ^= ENDIAN32(x);
+    x = (r21 >> 12) ^ (r23 << 9);
+    v[10] ^= ENDIAN32(x);
+    v[11] ^= ENDIAN32(r25);
+}
+
+void xe_fixerr(void *block)
+{
+    int i, j;
+    uint32_t x;
+    uint32_t r16, r17, r19, r21, r23, r25;
+    uint32_t *v = (uint32_t *) block;
+
+    xe_compute(block);
+
+    // Codeword:    r16 r17 r19 r21 r23 r25
+    // Bit offset:  0   16  33  52  73  96  121
+    r16 = ENDIAN32(v[8]);
+    x   = ENDIAN32(v[9]);
+    r17 = (r16 >> 16) ^ (x << 16);
+    r19 = x >> 1;
+    r23 = ENDIAN32(v[10]);
+    r21 = (x >> 20) ^ (r23 << 12);
+    r23 >>= 9;
+    r25 = ENDIAN32(v[11]);
+
+    MASK_UNFOLD(r16, 16);
+    MASK_UNFOLD(r17, 17);
+    MASK_UNFOLD(r19, 19);
+    MASK_UNFOLD(r21, 21);
+    MASK_UNFOLD(r23, 23);
+    MASK_UNFOLD(r25, 25);
+
+    for (i = 0; i < 8; i++) {
+        x = ENDIAN32(v[i]);
+        for (j = 0; j < 4; j++) {
+            x ^= ((0x44444444 + (((r16 >> j) & 0x11111111) +
+                ((r17 >> j) & 0x11111111) + ((r19 >> j) & 0x11111111) +
+                ((r21 >> j) & 0x11111111) + ((r23 >> j) & 0x11111111) +
+                ((r25 >> j) & 0x11111111))) & 0x88888888) >> (3 - j);
+        }
+        v[i] = ENDIAN32(x);
+
+        if (i < 7) {
+            ROTL32_REGN(r17, 17);
+            ROTL32_REGN(r19, 19);
+            ROTL32_REGN(r21, 21);
+            ROTL32_REGN(r23, 23);
+            ROTL32_REGN(r25, 25);
+        }
+    }
+}
+
+#endif
+
+

--- a/crypto_kem/r5nd/ref/xecc.h
+++ b/crypto_kem/r5nd/ref/xecc.h
@@ -1,0 +1,13 @@
+//  xecc.h
+//  2018-06-15  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+#ifndef _XECC_H_
+#define _XECC_H_
+
+// Add error correction to (payload | xe). On first round, zeroize xe.
+void xe_compute(void *block);
+
+// fix errors on block (payload | xe)
+void xe_fixerr(void *block);
+
+#endif /* _XECC_H_ */

--- a/crypto_kem/r5nd/ref/xof_hash.c
+++ b/crypto_kem/r5nd/ref/xof_hash.c
@@ -1,0 +1,26 @@
+//  xof_hash.c
+//  2018-06-15  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+#include "xof_hash.h"
+
+void XOF_absorb(XOF_ctx *ctx, const void *data, size_t len)
+{
+    shake256_absorb(ctx->st, data, len);
+    ctx->pt = SHAKE256_RATE;
+}
+
+void XOF_squeeze(XOF_ctx *ctx, void *data, size_t len)
+{
+    size_t i, j;
+
+    i = ctx->pt;
+    for (j = 0; j < len; j++) {
+        if (i >= SHAKE256_RATE) {
+            shake256_squeezeblocks(ctx->byt, 1, ctx->st);
+            i = 0;
+        }
+        ((uint8_t *) data)[j] = ctx->byt[i++];
+    }
+    ctx->pt = i;
+}
+

--- a/crypto_kem/r5nd/ref/xof_hash.h
+++ b/crypto_kem/r5nd/ref/xof_hash.h
@@ -1,0 +1,28 @@
+//  xof_hash.h
+//  2018-06-15  Markku-Juhani O. Saarinen <mjos@iki.fi>
+
+#ifndef _XOF_HASH_H_
+#define _XOF_HASH_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#include "fips202.h"
+#include "keccakf1600.h"
+
+typedef struct {
+    uint64_t st[25];
+    uint8_t byt[SHAKE256_RATE];
+    size_t pt;
+} XOF_ctx;
+
+// prototypes
+void XOF_absorb(XOF_ctx *ctx, const void *data, size_t len);
+void XOF_squeeze(XOF_ctx *ctx, void *data, size_t len);
+
+#define XOF_hash(output, input, input_byte_len, output_byte_len)        \
+    shake256((unsigned char *) (output), (size_t) (output_byte_len),    \
+            (const unsigned char *) (input), (size_t) (input_byte_len))
+
+#endif /* _XOF_HASH_H_ */
+


### PR DESCRIPTION
After reading #15 i got interested and started integrating Round5. The code is from the `master` branch of [the repository linked in #15](https://github.com/round5/r5nd_tiny), commit `84fdfe3`. I removed some unnecessary files (in `supp` directory) and adapted the calls to the randomness functions.

As described in this repository's Readme, I added `R5ND_3KEM` as a default parameter set as - according to the authors - it provides NIST security level 3. See `params.h` and `README.md` for more details.

Sadly, I still do not have an `stm32f4discovery` board available to actually check the integration. However, compilation works fine and i can succesfully generate testvectors on the host. It'd be great if someone could run the benchmarks on the actual hardware.

I tested the integration within our [Port of this library as a package for RIOT OS](https://github.com/jowlo/pqm4/tree/riot-port) and everything seems to work fine there, however, that fork uses a different build system.