### PR TITLE
Refactor kindi256342 to not use dynamic memory allocations 

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ executions is reported in parantheses.
 | scheme | implementation | key generation [bytes] | encapsulation [bytes] | decapsulation [bytes] |
 | ------ | -------------- | ----------------------- | ---------------------- | -----------------------|
 | frodo640-cshake | opt | 36,536 |  58,328 | 68,680 |
-| kindi256342 | ref | 10,632 |  10,736 | 16,912 |
+| kindi256342 | ref | 59,864 | 71,000 | 83,336 |
 | kyber768 | m4 | 10,304 |  13,464 | 14,624 |
 | kyber768 | ref | 10,304 |  13,464 | 14,624 |
 | newhope1024cca | m4 | 11,160 |  17,456 | 19,656 |

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ executions is reported in parantheses.
 | scheme | implementation | key generation [cycles] | encapsulation [cycles] | decapsulation [cycles] |
 | ------ | -------------- | ----------------------- | ---------------------- | -----------------------|
 | frodo640-cshake (10 executions) | opt | AVG: 94,191,951 <br /> MIN: 94,191,921 <br /> MAX: 94,192,027 |  AVG: 111,688,861 <br /> MIN: 111,688,796 <br /> MAX: 111,688,895 | AVG: 112,156,317 <br /> MIN: 112,156,264 <br /> MAX: 112,156,389 |
-| kindi256342 (10 executions) | ref | AVG: 22,940,741 <br /> MIN: 22,928,176 <br /> MAX: 22,947,668 |  AVG: 29,659,234 <br /> MIN: 29,645,532 <br /> MAX: 29,674,037 | AVG: 37,821,962 <br /> MIN: 37,805,302 <br /> MAX: 37,840,627 |
+| kindi256342 (10 executions) | ref | AVG: 21,793,959 <br /> MIN: 21,784,358 <br /> MAX: 21,803,111 |  AVG: 28,172,479 <br /> MIN: 28,155,635 <br /> MAX: 28,183,740 | AVG: 37,125,697 <br /> MIN: 37,105,911 <br /> MAX: 37,138,137 |
 | kyber768 (10 executions) | m4 | AVG: 1,200,351 <br /> MIN: 1,199,831 <br /> MAX: 1,200,671 |  AVG: 1,497,789 <br /> MIN: 1,497,296 <br /> MAX: 1,498,094 | AVG: 1,526,564 <br /> MIN: 1,526,070 <br /> MAX: 1,526,868 |
 | kyber768 (10 executions) | ref | AVG: 1,379,979 <br /> MIN: 1,379,339 <br /> MAX: 1,380,339 |  AVG: 1,797,604 <br /> MIN: 1,796,996 <br /> MAX: 1,797,947 | AVG: 1,950,350 <br /> MIN: 1,949,742 <br /> MAX: 1,950,693 |
 | newhope1024cca (10 executions) | ref | AVG: 1,502,435 <br /> MIN: 1,502,179 <br /> MAX: 1,502,707 |  AVG: 2,370,157 <br /> MIN: 2,369,901 <br /> MAX: 2,370,429 | AVG: 2,517,215 <br /> MIN: 2,516,959 <br /> MAX: 2,517,488 |

--- a/crypto_kem/kindi256342/ref/core.h
+++ b/crypto_kem/kindi256342/ref/core.h
@@ -11,10 +11,8 @@
 #include "gen_randomness.h"
 
 typedef struct {
-
-	poly_d *b;
-	uint8_t *seed;
-
+	poly_d b[KINDI_KEM_L];
+	uint8_t seed[KINDI_KEM_SEEDSIZE];
 } kindi_pk;
 
 void xor_bytes(uint8_t *r, const uint8_t *f, const uint8_t *g, int len);

--- a/crypto_kem/kindi256342/ref/gen_randomness.c
+++ b/crypto_kem/kindi256342/ref/gen_randomness.c
@@ -4,7 +4,7 @@
 void kindi_crypto_stream_h(uint8_t *out, unsigned long long outlen,
 		const uint8_t *in, unsigned long long inlen) {
 
-	uint8_t *in1 = malloc(inlen + 1);
+	uint8_t in1[inlen + 1];
 	memcpy(in1, in, inlen);
 	in1[inlen] = 4;
 #if KINDI_KEM_SHAKEMODE == 128
@@ -12,9 +12,6 @@ void kindi_crypto_stream_h(uint8_t *out, unsigned long long outlen,
 #elif KINDI_KEM_SHAKEMODE == 256
 	shake256(out, outlen, in1, inlen+1);
 #endif
-
-	free(in1);
-
 }
 
 //H'
@@ -36,7 +33,7 @@ void gen_randomness(poly_d *s, uint8_t *u, uint8_t *s1) {
 #if KINDI_KEM_S1BITS == 1
 	int i, a, x;
 
-	uint8_t *buffer = malloc(BUFFERLEN);
+	uint8_t buffer[BUFFERLEN];
 #if KINDI_KEM_SHAKEMODE == 128
 	shake128(buffer, BUFFERLEN, s1, KINDI_KEM_S1SIZE);
 #elif KINDI_KEM_SHAKEMODE == 256
@@ -74,11 +71,10 @@ void gen_randomness(poly_d *s, uint8_t *u, uint8_t *s1) {
 
 	memcpy(u, buffer + pos, KINDI_KEM_MESSAGEBYTES);
 
-	free(buffer);
 #elif KINDI_KEM_S1BITS == 2
 	int i, a, x;
 
-	uint8_t *buffer = malloc(BUFFERLEN);
+	uint8_t buffer[BUFFERLEN];
 #if KINDI_KEM_SHAKEMODE == 128
 	shake128(buffer, BUFFERLEN, s1, KINDI_KEM_S1SIZE);
 #elif KINDI_KEM_SHAKEMODE == 256
@@ -114,9 +110,6 @@ void gen_randomness(poly_d *s, uint8_t *u, uint8_t *s1) {
 	}
 
 	memcpy(u, buffer + pos, KINDI_KEM_MESSAGEBYTES);
-
-	free(buffer);
-
 #endif
 }
 

--- a/crypto_kem/kindi256342/ref/gen_randomness.h
+++ b/crypto_kem/kindi256342/ref/gen_randomness.h
@@ -3,7 +3,6 @@
 
 #include <string.h>
 #include <stdlib.h>
-#include <malloc.h>
 
 #include "params.h"
 #include "fips202.h"

--- a/crypto_kem/kindi256342/ref/kem.c
+++ b/crypto_kem/kindi256342/ref/kem.c
@@ -8,11 +8,8 @@ int crypto_kem_keypair(unsigned char *pk, unsigned char *sk) {
 	memset(sk, 0, KINDI_KEM_SECRETKEYBYTES);
 	memset(pk, 0, KINDI_KEM_PUBLICKEYBYTES);
 	kindi_pk pk_p;
-	poly_d *sk_p;
-
-	pk_p.b = (poly_d*) memalign(32, KINDI_KEM_L * sizeof(poly_d));
-	pk_p.seed = (uint8_t *) malloc(KINDI_KEM_SEEDSIZE);
-	sk_p = (poly_d*) memalign(32, KINDI_KEM_L * sizeof(poly_d));
+	poly_d sk_p[KINDI_KEM_L];
+	
 	kindi_keygen(&pk_p, sk_p);
 
 	int offset_pk = 0;
@@ -35,10 +32,6 @@ int crypto_kem_keypair(unsigned char *pk, unsigned char *sk) {
 	}
 
 	memcpy(sk + offset_sk, pk, KINDI_KEM_PUBLICKEYBYTES);
-
-	free(pk_p.b);
-	free(pk_p.seed);
-	free(sk_p);
 	return 0;
 }
 
@@ -47,9 +40,6 @@ int crypto_kem_enc(unsigned char *ct, unsigned char *ss,
 
 	int i;
 	kindi_pk pk_p;
-
-	pk_p.b = (poly_d*) memalign(32, KINDI_KEM_L * sizeof(poly_d));
-	pk_p.seed = (uint8_t *) malloc(KINDI_KEM_SEEDSIZE);
 
 	// convert pk from byte-array to polynomials and decompress
 	int offset_pk = 0;
@@ -62,10 +52,6 @@ int crypto_kem_enc(unsigned char *ct, unsigned char *ss,
 	memcpy(pk_p.seed, pk + offset_pk, KINDI_KEM_SEEDSIZE);
 
 	kindi_kem_encaps(&pk_p, ct, ss);
-
-	free(pk_p.b);
-	free(pk_p.seed);
-
 	return 0;
 
 }
@@ -75,11 +61,8 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct,
 	int i;
 	kindi_pk pk_p;
 
-	poly_d *cipher = (poly_d *) memalign(32,
-	KINDI_KEM_NUMBER_CIPHERPOLY * sizeof(poly_d));
-	pk_p.b = (poly_d*) memalign(32, KINDI_KEM_L * sizeof(poly_d));
-	pk_p.seed = (uint8_t *) malloc(KINDI_KEM_SEEDSIZE);
-	poly_d *sk_p = (poly_d*) memalign(32, KINDI_KEM_L * sizeof(poly_d));
+	poly_d cipher[KINDI_KEM_NUMBER_CIPHERPOLY];
+	poly_d sk_p[KINDI_KEM_L];
 
 	int offset_sk = 0;
 	int offset_c = 0;
@@ -109,11 +92,5 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct,
 	}
 
 	kindi_kem_decaps(sk_p, &pk_p, cipher, ct, ss);
-
-	free(pk_p.b);
-	free(pk_p.seed);
-	free(sk_p);
-	free(cipher);
-
 	return 0;
 }

--- a/crypto_kem/kindi256342/ref/poly.c
+++ b/crypto_kem/kindi256342/ref/poly.c
@@ -34,7 +34,7 @@ void poly_copy_d(poly_d r, poly_d p) {
 void poly_setrandom_rsec(poly_d *r,poly_d *e, uint8_t *gamma) {
 
 	int bufferlen = 2*KINDI_KEM_L*KINDI_KEM_N*(KINDI_KEM_LOG2RSEC+1)/8;
-	uint8_t *buffer = malloc(bufferlen);
+	uint8_t buffer[bufferlen];
 	shake128(buffer,bufferlen,gamma,KINDI_KEM_SEEDSIZE);
 	int i;
 	uint64_t offset =0;
@@ -46,15 +46,14 @@ void poly_setrandom_rsec(poly_d *r,poly_d *e, uint8_t *gamma) {
 		offset+= KINDI_KEM_N*(KINDI_KEM_LOG2RSEC+1)/8;
 	}
 
-	free(buffer);
 }
 
 // generate LxL matrix of polynomials from a seed \mu
-void poly_gen_matrix(poly_d **A, uint8_t * seed) {
+void poly_gen_matrix(poly_d A[KINDI_KEM_L][KINDI_KEM_L], uint8_t * seed) {
 
 	uint32_t tmp;
 	int buffer_size = KINDI_KEM_L * KINDI_KEM_L * KINDI_KEM_N * KINDI_KEM_BYTESLOGQ;
-	uint8_t *buffer = malloc(buffer_size);
+	uint8_t buffer[buffer_size];
 
 	shake128(buffer, buffer_size, seed, KINDI_KEM_SEEDSIZE);
 	int a, x, i, y;
@@ -70,7 +69,6 @@ void poly_gen_matrix(poly_d **A, uint8_t * seed) {
 
 			}
 
-	free(buffer);
 }
 
 

--- a/crypto_kem/kindi256342/ref/poly.h
+++ b/crypto_kem/kindi256342/ref/poly.h
@@ -74,7 +74,7 @@ void poly_type_convert_df(poly_f f, poly_d d);
 void poly_copy_d(poly_d r, poly_d p);
 
 void poly_setrandom_rsec(poly_d *r,poly_d *e, uint8_t *gamma);
-void poly_gen_matrix(poly_d **A, uint8_t* seed);
+void poly_gen_matrix(poly_d A[KINDI_KEM_L][KINDI_KEM_L], uint8_t* seed);
 
 void poly_sub_constant(poly_d r, const poly_d f, const int64_t c);
 void poly_add_nored(poly_d r, const poly_d f, const poly_d g);


### PR DESCRIPTION
I've refactored kindi to use local stack space instead of malloc.
The performance gain is quite huge.

This makes pqm4 `malloc`/`memalign`/`calloc`/`free` free. 
For future PRs we should enforce that as well. 