### PR TITLE
Check for incorrect keys when benchmarking KEMs

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -21,6 +21,14 @@ def benchmarkBinary(benchmark, binary):
         return
 
     result = utils.m4run(binpath)
+    if 'ERROR KEYS' in result:
+        print("")
+        print("!!! KEY MISMATCH DURING BENCHMARKING !!!")
+        print("  This could indicate illegal stack usage,")
+        print("  leading to errors when measurement interrupts occur.")
+        print("")
+        print("  .. exiting with errors!")
+        sys.exit(1)
 
     timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%d%H%M%S')
     filename = os.path.join('benchmarks/', benchmark, primitive, scheme, implementation, timestamp)

--- a/crypto_kem/speed.c
+++ b/crypto_kem/speed.c
@@ -23,7 +23,7 @@ static void printcycles(const char *s, unsigned long long c)
 
 int main(void)
 {
-  unsigned char ss[CRYPTO_BYTES];
+  unsigned char key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
   unsigned char sk[CRYPTO_SECRETKEYBYTES];
   unsigned char pk[CRYPTO_PUBLICKEYBYTES];
   unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
@@ -47,16 +47,23 @@ int main(void)
   // Encapsulation
   t0 = systick_get_value();
   overflowcnt = 0;
-  crypto_kem_enc(ct, ss, pk);
+  crypto_kem_enc(ct, key_a, pk);
   t1 = systick_get_value();
   printcycles("encaps cycles: ", (t0+overflowcnt*2400000llu)-t1);
 
   // Decapsulation
   t0 = systick_get_value();
   overflowcnt = 0;
-  crypto_kem_dec(ss, ct, sk);
+  crypto_kem_dec(key_b, ct, sk);
   t1 = systick_get_value();
   printcycles("decaps cycles: ", (t0+overflowcnt*2400000llu)-t1);
+
+  if (memcmp(key_a, key_b, CRYPTO_BYTES)) {
+    send_USART_str("ERROR KEYS\n");
+  }
+  else {
+    send_USART_str("OK KEYS\n");
+  }
 
   send_USART_str("#");
   while(1);

--- a/crypto_kem/stack.c
+++ b/crypto_kem/stack.c
@@ -67,7 +67,7 @@ static int test_keys(void) {
     send_stack_usage("key gen stack usage", stack_key_gen);
     send_stack_usage("encaps stack usage", stack_encaps);
     send_stack_usage("decaps stack usage", stack_decaps);
-    send_USART_str("KEYS CORRECT\n");
+    send_USART_str("OK KEYS\n");
     return 0;
   }
 }


### PR DESCRIPTION
This may occur e.g. when implementations make illegal use of the stack. It may be tempting to read/write beyond the stack pointer, but if measurement interrupts occurs this data gets overwritten.