### PR TITLE
Refactor crypto_hash_sha512 and add sha384

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GDB         = $(PREFIX)-gdb
 
 ARCH_FLAGS  = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 DEFINES     = -DSTM32F4
-OBJS        = obj/stm32f4_wrapper.o obj/fips202.o obj/keccakf1600.o obj/crypto_hash_sha512.o
+OBJS        = obj/stm32f4_wrapper.o obj/fips202.o obj/keccakf1600.o obj/sha2.o
 RANDOMBYTES = obj/randombytes.o
 
 CFLAGS     += -O3 \
@@ -31,7 +31,7 @@ LD_HOST    = gcc
 CFLAGS_HOST = -O3 -Wall -Wextra -Wpedantic
 LDFLAGS_HOST =
 
-OBJS_HOST  = obj-host/fips202.o obj-host/keccakf1600.o obj-host/crypto_hash_sha512.o
+OBJS_HOST  = obj-host/fips202.o obj-host/keccakf1600.o obj-host/sha2.o
 
 KEMS=$(wildcard crypto_kem/*/*)
 SIGNS=$(wildcard crypto_sign/*/*)
@@ -253,7 +253,7 @@ obj/keccakf1600.o:  common/keccakf1600.S
 	$(CC) $(CFLAGS) -o $@ -c $^
 
 
-obj/crypto_hash_sha512.o:  common/crypto_hash_sha512.c
+obj/sha2.o:  common/sha2.c
 	mkdir -p obj
 	$(CC) $(CFLAGS) -o $@ -c $^
 

--- a/README.md
+++ b/README.md
@@ -304,21 +304,22 @@ new subdirectory under `crypto_sign/`.
    The SHAKE and cSHAKE functions are also accessible via the absorb-squeezeblocks functions, which offer incremental
    output generation (but not incremental input handling).
 
-## Using optimised SHA512
+## Using optimised SHA384 and SHA512
 
-  Some schemes submitted to NIST make use of SHA512 for hashing.
+  Some schemes submitted to NIST make use of SHA384 or SHA512 for hashing.
   We've experimented with assembly-optimised SHA512, but found that the speed-up
   achievable with this compared to the C implementation from
   [SUPERCOP](http://bench.cr.yp.to/) is negligible
   when compiled using `arm-none-eabi-gcc-8.2.0`.
   For older compiler versions (e.g. `5.4.1`) hand-optimised assembly implementations
   were significantly faster.
-  We've therefore decided to only include a C version of SHA512.
+  We've therefore decided to only include a C version of SHA384 and SHA512.
   The available functions are:
    ```c
-  int crypto_hash_sha512(unsigned char *out,const unsigned char *in,unsigned long long inlen);
+  int sha384(unsigned char *output, const unsigned char *input, unsigned long long inlen);
+  int sha512(unsigned char *output, const unsigned char *input, unsigned long long inlen);
    ```
-  Implementations can make use of this by including `crypto_hash_sha512.h`.
+  Implementations can make use of this by including `sha2.h`.
 
 ## Bibliography
 

--- a/common/crypto_hash_sha512.h
+++ b/common/crypto_hash_sha512.h
@@ -1,8 +1,0 @@
-#ifndef crypto_hash_sha512_h
-#define crypto_hash_sha512_h
-
-int crypto_hash_sha512(unsigned char *out,const unsigned char *in,unsigned long long inlen);
-
-#endif
-
-

--- a/common/fips202.c
+++ b/common/fips202.c
@@ -169,7 +169,7 @@ void shake128_squeezeblocks(unsigned char *output, unsigned long long nblocks, u
   keccak_squeezeblocks(output, nblocks, s, SHAKE128_RATE);
 }
 
-void shake128(unsigned char *output, unsigned long long outlen, const unsigned char *input,  unsigned long long inlen)
+void shake128(unsigned char *output, unsigned long long outlen, const unsigned char *input, unsigned long long inlen)
 {
   uint64_t s[25] = {0};
   unsigned char t[SHAKE128_RATE];
@@ -220,7 +220,7 @@ void shake256_squeezeblocks(unsigned char *output, unsigned long long nblocks, u
                - unsigned long long inlen:   length of input in bytes
 **************************************************/
 void shake256(unsigned char *output, unsigned long long outlen,
-              const unsigned char *input,  unsigned long long inlen)
+              const unsigned char *input, unsigned long long inlen)
 {
   uint64_t s[25] = {0};
   unsigned char t[SHAKE256_RATE];
@@ -253,7 +253,7 @@ void shake256(unsigned char *output, unsigned long long outlen,
 *              - const unsigned char *input: pointer to input
 *              - unsigned long long inlen:   length of input in bytes
 **************************************************/
-void sha3_256(unsigned char *output, const unsigned char *input,  unsigned long long inlen)
+void sha3_256(unsigned char *output, const unsigned char *input, unsigned long long inlen)
 {
   uint64_t s[25] = {0};
   unsigned char t[SHA3_256_RATE];
@@ -278,7 +278,7 @@ void sha3_256(unsigned char *output, const unsigned char *input,  unsigned long 
 *              - const unsigned char *input: pointer to input
 *              - unsigned long long inlen:   length of input in bytes
 **************************************************/
-void sha3_512(unsigned char *output, const unsigned char *input,  unsigned long long inlen)
+void sha3_512(unsigned char *output, const unsigned char *input, unsigned long long inlen)
 {
   uint64_t s[25] = {0};
   unsigned char t[SHA3_512_RATE];

--- a/common/fips202.h
+++ b/common/fips202.h
@@ -10,7 +10,7 @@
 
 void shake128_absorb(uint64_t *s, const unsigned char *input, unsigned int inputByteLen);
 void shake128_squeezeblocks(unsigned char *output, unsigned long long nblocks, uint64_t *s);
-void shake128(unsigned char *output, unsigned long long outlen, const unsigned char *input,  unsigned long long inlen);
+void shake128(unsigned char *output, unsigned long long outlen, const unsigned char *input, unsigned long long inlen);
 
 void cshake128_simple_absorb(uint64_t *s, uint16_t cstm, const unsigned char *in, unsigned long long inlen);
 void cshake128_simple_squeezeblocks(unsigned char *output, unsigned long long nblocks, uint64_t *s);
@@ -18,13 +18,13 @@ void cshake128_simple(unsigned char *output, unsigned long long outlen, uint16_t
 
 void shake256_absorb(uint64_t *s, const unsigned char *input, unsigned int inputByteLen);
 void shake256_squeezeblocks(unsigned char *output, unsigned long long nblocks, uint64_t *s);
-void shake256(unsigned char *output, unsigned long long outlen, const unsigned char *input,  unsigned long long inlen);
+void shake256(unsigned char *output, unsigned long long outlen, const unsigned char *input, unsigned long long inlen);
 
 void cshake256_simple_absorb(uint64_t *s, uint16_t cstm, const unsigned char *in, unsigned long long inlen);
 void cshake256_simple_squeezeblocks(unsigned char *output, unsigned long long nblocks, uint64_t *s);
 void cshake256_simple(unsigned char *output, unsigned long long outlen, uint16_t cstm, const unsigned char *in, unsigned long long inlen);
 
-void sha3_256(unsigned char *output, const unsigned char *input,  unsigned long long inlen);
-void sha3_512(unsigned char *output, const unsigned char *input,  unsigned long long inlen);
+void sha3_256(unsigned char *output, const unsigned char *input, unsigned long long inlen);
+void sha3_512(unsigned char *output, const unsigned char *input, unsigned long long inlen);
 
 #endif

--- a/common/sha2.h
+++ b/common/sha2.h
@@ -1,0 +1,9 @@
+#ifndef SHA2_H
+#define SHA2_H
+
+int sha384(unsigned char *output, const unsigned char *input, unsigned long long inlen);
+int sha512(unsigned char *output, const unsigned char *input, unsigned long long inlen);
+
+#endif
+
+

--- a/crypto_kem/ntru-kem-743/m4/poly.c
+++ b/crypto_kem/ntru-kem-743/m4/poly.c
@@ -18,7 +18,7 @@
 #include "param.h"
 #include "poly.h"
 #include "randombytes.h"
-#include "crypto_hash_sha512.h"
+#include "sha2.h"
 
 #define PAD(N) ((N + 0x000f) & 0xfff0)
 
@@ -370,7 +370,7 @@ trinary_poly_gen_w_seed(
 
     seed_ptr = (uint64_t*) seed;
 
-    crypto_hash_sha512(seed, seed, seed_len);
+    sha512(seed, seed, seed_len);
 
 
 
@@ -381,7 +381,7 @@ trinary_poly_gen_w_seed(
         j++;
         if(j==8)
         {
-            crypto_hash_sha512(seed, seed, LENGTH_OF_HASH);
+            sha512(seed, seed, LENGTH_OF_HASH);
             j = 0;
         }
         for (i =0;i<6;i++)
@@ -405,7 +405,7 @@ trinary_poly_gen_w_seed(
         j++;
         if(j==8)
         {
-            crypto_hash_sha512(seed, seed, LENGTH_OF_HASH);
+            sha512(seed, seed, LENGTH_OF_HASH);
             j = 0;
         }
         for (i =0;i<6;i++)
@@ -440,14 +440,14 @@ rand_tri_poly_from_seed(
   i = 0;
   j = 0;
 
-  crypto_hash_sha512(seed, seed, seed_len);
+  sha512(seed, seed, seed_len);
 
   while (i<N)
   {
       tmp = (uint8_t)seed[j++];
       if(j==64)
       {
-          crypto_hash_sha512(seed, seed, seed_len);
+          sha512(seed, seed, seed_len);
           j=0;
       }
       for (k=0;k<4;k++)

--- a/crypto_kem/ntru-kem-743/ref/NTRUEncrypt.c
+++ b/crypto_kem/ntru-kem-743/ref/NTRUEncrypt.c
@@ -11,7 +11,7 @@
 #include "param.h"
 #include "poly.h"
 #include "randombytes.h"
-#include "crypto_hash_sha512.h"
+#include "sha2.h"
 #include "NTRUEncrypt.h"
 
 
@@ -325,8 +325,8 @@ generate_r(
     memset(seed, 0, sizeof(unsigned char)* LENGTH_OF_HASH*2);
 
     /* hash message/public key into a string 'seed'*/
-    crypto_hash_sha512(seed, (unsigned char*)msg, param->N*2);
-    crypto_hash_sha512(seed+LENGTH_OF_HASH, (unsigned char*)h, param->N*2);
+    sha512(seed, (unsigned char*)msg, param->N*2);
+    sha512(seed+LENGTH_OF_HASH, (unsigned char*)h, param->N*2);
 
 
     /* use the seed to generate r */
@@ -358,7 +358,7 @@ mask_m(
     seed  = (unsigned char*) buf;
     mask  = (uint16_t *) (seed + LENGTH_OF_HASH);
 
-    crypto_hash_sha512(seed, (unsigned char*) rh, param->N*sizeof(uint16_t)/sizeof(unsigned char));
+    sha512(seed, (unsigned char*) rh, param->N*sizeof(uint16_t)/sizeof(unsigned char));
 
     rand_tri_poly_from_seed(mask, param->N, seed, LENGTH_OF_HASH);
 
@@ -400,7 +400,7 @@ unmask_m(
     mask  = (uint16_t *) (seed + LENGTH_OF_HASH);
 
 
-    crypto_hash_sha512(seed, (unsigned char*) rh, param->N*sizeof(uint16_t)/sizeof(unsigned char));
+    sha512(seed, (unsigned char*) rh, param->N*sizeof(uint16_t)/sizeof(unsigned char));
 
     rand_tri_poly_from_seed(mask, param->N, seed, LENGTH_OF_HASH);
 

--- a/crypto_kem/ntru-kem-743/ref/kem.c
+++ b/crypto_kem/ntru-kem-743/ref/kem.c
@@ -10,7 +10,7 @@
 #include "api.h"
 #include "NTRUEncrypt.h"
 #include "packing.h"
-#include "crypto_hash_sha512.h"
+#include "sha2.h"
 #include "randombytes.h"
 
 /* kem and encryption use a same key gen */
@@ -87,8 +87,8 @@ int crypto_kem_enc(
     pack_public_key (ct, param, cpoly);
 
     /* ss = Hash (shared_secret | h) */
-    crypto_hash_sha512(shared_secret + CRYPTO_BYTES, (unsigned char*)h, sizeof(uint16_t)*param->padN);
-    crypto_hash_sha512(shared_secret, shared_secret, LENGTH_OF_HASH + CRYPTO_BYTES);
+    sha512(shared_secret + CRYPTO_BYTES, (unsigned char*)h, sizeof(uint16_t)*param->padN);
+    sha512(shared_secret, shared_secret, LENGTH_OF_HASH + CRYPTO_BYTES);
     memcpy (ss, shared_secret, CRYPTO_BYTES);
 
 
@@ -141,8 +141,8 @@ int crypto_kem_dec(
     }
 
     /* deriving the session key */
-    crypto_hash_sha512(shared_secret+CRYPTO_BYTES, (unsigned char*) h, sizeof(uint16_t)*param->padN);
-    crypto_hash_sha512(shared_secret, shared_secret, LENGTH_OF_HASH + CRYPTO_BYTES);
+    sha512(shared_secret+CRYPTO_BYTES, (unsigned char*) h, sizeof(uint16_t)*param->padN);
+    sha512(shared_secret, shared_secret, LENGTH_OF_HASH + CRYPTO_BYTES);
     memcpy (ss, shared_secret, CRYPTO_BYTES);
     return 0;
 }

--- a/crypto_kem/ntru-kem-743/ref/poly.c
+++ b/crypto_kem/ntru-kem-743/ref/poly.c
@@ -18,7 +18,7 @@
 #include "param.h"
 #include "poly.h"
 #include "randombytes.h"
-#include "crypto_hash_sha512.h"
+#include "sha2.h"
 
 #define PAD(N) ((N + 0x000f) & 0xfff0)
 
@@ -491,7 +491,7 @@ trinary_poly_gen_w_seed(
 
     seed_ptr = (uint64_t*) seed;
 
-    crypto_hash_sha512(seed, seed, seed_len);
+    sha512(seed, seed, seed_len);
 
 
 
@@ -502,7 +502,7 @@ trinary_poly_gen_w_seed(
         j++;
         if(j==8)
         {
-            crypto_hash_sha512(seed, seed, LENGTH_OF_HASH);
+            sha512(seed, seed, LENGTH_OF_HASH);
             j = 0;
         }
         for (i =0;i<6;i++)
@@ -526,7 +526,7 @@ trinary_poly_gen_w_seed(
         j++;
         if(j==8)
         {
-            crypto_hash_sha512(seed, seed, LENGTH_OF_HASH);
+            sha512(seed, seed, LENGTH_OF_HASH);
             j = 0;
         }
         for (i =0;i<6;i++)
@@ -561,14 +561,14 @@ rand_tri_poly_from_seed(
   i = 0;
   j = 0;
 
-  crypto_hash_sha512(seed, seed, LENGTH_OF_HASH);
+  sha512(seed, seed, LENGTH_OF_HASH);
 
   while (i<N)
   {
       tmp = (uint8_t)seed[j++];
       if(j==64)
       {
-          crypto_hash_sha512(seed, seed, LENGTH_OF_HASH);
+          sha512(seed, seed, LENGTH_OF_HASH);
           j=0;
       }
       for (k=0;k<4;k++)

--- a/crypto_kem/rlizard-1024-11/m4/RLizard.c
+++ b/crypto_kem/rlizard-1024-11/m4/RLizard.c
@@ -4,7 +4,7 @@
 
 #include "RLizard.h"
 #include "randombytes.h"
-#include "crypto_hash_sha512.h"
+#include "sha2.h"
 #include "libkeccak/SP800-185.h"
 
 extern  void polymul_asm(uint16_t *h, const uint16_t *f, const uint16_t *g);
@@ -291,7 +291,7 @@ int crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk
 #endif
 
 	// Compute d = H'(delta)
-	crypto_hash_sha512((unsigned char *) hash, (unsigned char*)delta, sizeof(delta));
+	sha512((unsigned char *) hash, (unsigned char*)delta, sizeof(delta));
 #ifdef RING_CATEGORY1
 	for (j = 0; j < 4; ++j) {
 		ct[LWE_N + LWE_N + j * 8] = (unsigned char)(hash[j] >> 56);
@@ -375,7 +375,7 @@ int crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk
 	uint64_t hash_t2[(LWE_N + LWE_N + (LAMBDA / 4) + (LWE_N / 8)) / 8];
 	memcpy((unsigned char*)hash_t2, (unsigned char*)ct, LWE_N + LWE_N + (LAMBDA / 4));
 	memcpy((unsigned char*)hash_t2 + LWE_N + LWE_N + (LAMBDA / 4), (unsigned char*)delta, (LWE_N / 8));
-	crypto_hash_sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
+	sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
 #endif
 #if defined(RING_CATEGORY3_N1024) || defined(RING_CATEGORY3_N2048) || defined(RING_CATEGORY5)
 	for (i = 0; i < LWE_N; ++i) {
@@ -390,7 +390,7 @@ int crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk
 	uint64_t hash_t2[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 	memcpy((unsigned char*)hash_t2, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 	memcpy((unsigned char*)hash_t2 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)delta, (LWE_N / 8));
-	crypto_hash_sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
+	sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
 #endif
 	for (i = 0; i < LAMBDA / 32; ++i) {
 		ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -594,7 +594,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 #endif
 
 	// Compute d' = H'(delta)
-	crypto_hash_sha512((unsigned char *)hash, (unsigned char*)delta, sizeof(delta));
+	sha512((unsigned char *)hash, (unsigned char*)delta, sizeof(delta));
 
 	// Initialize c2' as q/2 * delta
 	for (i = 0; i < LWE_N; ++i) { c2[i] = decomp_delta[i] << _16_LOG_T; }
@@ -669,7 +669,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t2[(LWE_N + LWE_N + (LAMBDA / 4) + (LWE_N / 8)) / 8];
 		memcpy((unsigned char*)hash_t2, (unsigned char*)ct, LWE_N + LWE_N + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t2 + LWE_N + LWE_N + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
+		sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
 
 		for (j = 0; j < 4; ++j) {
 			ss[j * 8] = (unsigned char)(hash[j] >> 56);
@@ -690,7 +690,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t2[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 		memcpy((unsigned char*)hash_t2, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t2 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
+		sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
 
 		for (j = 0; j < 6; ++j) {
 			ss[j * 8] = (unsigned char)(hash[j] >> 56);
@@ -712,7 +712,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t2[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 		memcpy((unsigned char*)hash_t2, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t2 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
+		sha512((unsigned char *) hash, (unsigned char*)hash_t2, sizeof(hash_t2));
 
 		for (i = 0; i < 8; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -747,7 +747,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t3[(LWE_N + LWE_N + (LAMBDA / 4) + (LWE_N / 8)) / 8];
 		memcpy((unsigned char*)hash_t3, (unsigned char*)ct, LWE_N + LWE_N + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t3 + LWE_N + LWE_N + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char *) hash, (unsigned char*)hash_t3, sizeof(hash_t3));
+		sha512((unsigned char *) hash, (unsigned char*)hash_t3, sizeof(hash_t3));
 
 		for (i = 0; i < 4; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -764,7 +764,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t3[(LWE_N + LWE_N + (LAMBDA / 4) + (LWE_N / 8)) / 8];
 		memcpy((unsigned char*)hash_t3, (unsigned char*)ct, LWE_N + LWE_N + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t3 + LWE_N + LWE_N + (LAMBDA / 4), (unsigned char*)delta, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char *)hash, (unsigned char*)hash_t3, sizeof(hash_t3));
+		sha512((unsigned char *)hash, (unsigned char*)hash_t3, sizeof(hash_t3));
 
 		for (i = 0; i < 4; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -794,7 +794,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t3[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 		memcpy((unsigned char*)hash_t3, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t3 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char *)hash,(unsigned char*)hash_t3, sizeof(hash_t3));
+		sha512((unsigned char *)hash,(unsigned char*)hash_t3, sizeof(hash_t3));
 
 		for (i = 0; i < LAMBDA / 32; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -811,7 +811,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t3[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 		memcpy((unsigned char*)hash_t3, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t3 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)delta, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char *) hash, (unsigned char*)hash_t3, sizeof(hash_t3));
+		sha512((unsigned char *) hash, (unsigned char*)hash_t3, sizeof(hash_t3));
 
 		for (i = 0; i < LAMBDA / 32; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);

--- a/crypto_kem/rlizard-1024-11/ref/RLizard.c
+++ b/crypto_kem/rlizard-1024-11/ref/RLizard.c
@@ -4,7 +4,7 @@
 
 #include "RLizard.h"
 #include "randombytes.h"
-#include "crypto_hash_sha512.h"
+#include "sha2.h"
 #include "libkeccak/SP800-185.h"
 
 #define CRYPTO_SECRETKEYBYTES_WITHOUTPK (LWE_N + (LWE_N / 8))
@@ -271,7 +271,7 @@ int crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk
 #endif
 
 	// Compute d = H'(delta)
-	crypto_hash_sha512((unsigned char *)hash, (unsigned char *) delta, sizeof(delta));
+	sha512((unsigned char *)hash, (unsigned char *) delta, sizeof(delta));
 #ifdef RING_CATEGORY1
 	for (j = 0; j < 4; ++j) {
 		ct[LWE_N + LWE_N + j * 8] = (unsigned char)(hash[j] >> 56);
@@ -335,7 +335,7 @@ int crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk
 	uint64_t hash_t2[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 	memcpy((unsigned char*)hash_t2, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 	memcpy((unsigned char*)hash_t2 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)delta, (LWE_N / 8));
-	crypto_hash_sha512((unsigned char*)hash, (unsigned char*)hash_t2, sizeof(hash_t2));
+	sha512((unsigned char*)hash, (unsigned char*)hash_t2, sizeof(hash_t2));
 #endif
 	for (i = 0; i < LAMBDA / 32; ++i) {
 		ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -522,7 +522,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 #endif
 
 	// Compute d' = H'(delta)
-	crypto_hash_sha512((unsigned char*)hash, (unsigned char*)delta, sizeof(delta));
+	sha512((unsigned char*)hash, (unsigned char*)delta, sizeof(delta));
 
 	// Initialize c2' as q/2 * delta
 	for (i = 0; i < LWE_N; ++i) { c2[i] = decomp_delta[i] << _16_LOG_T; }
@@ -564,7 +564,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t2[(LWE_N + LWE_N + (LAMBDA / 4) + (LWE_N / 8)) / 8];
 		memcpy((unsigned char*)hash_t2, (unsigned char*)ct, LWE_N + LWE_N + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t2 + LWE_N + LWE_N + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char *)hash, (unsigned char *) hash_t2, sizeof(hash_t2));
+		sha512((unsigned char *)hash, (unsigned char *) hash_t2, sizeof(hash_t2));
 
 		for (j = 0; j < 4; ++j) {
 			ss[j * 8] = (unsigned char)(hash[j] >> 56);
@@ -585,7 +585,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t2[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 		memcpy((unsigned char*)hash_t2, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t2 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char*)hash, (unsigned char*)hash_t2, sizeof(hash_t2));
+		sha512((unsigned char*)hash, (unsigned char*)hash_t2, sizeof(hash_t2));
 
 		for (j = 0; j < 6; ++j) {
 			ss[j * 8] = (unsigned char)(hash[j] >> 56);
@@ -607,7 +607,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t2[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 		memcpy((unsigned char*)hash_t2, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t2 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char*)hash, (unsigned char*)hash_t2, sizeof(hash_t2));
+		sha512((unsigned char*)hash, (unsigned char*)hash_t2, sizeof(hash_t2));
 
 		for (i = 0; i < 8; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -642,7 +642,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t3[(LWE_N + LWE_N + (LAMBDA / 4) + (LWE_N / 8)) / 8];
 		memcpy((unsigned char*)hash_t3, (unsigned char*)ct, LWE_N + LWE_N + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t3 + LWE_N + LWE_N + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char*)hash, (unsigned char*)hash_t3, sizeof(hash_t3));
+		sha512((unsigned char*)hash, (unsigned char*)hash_t3, sizeof(hash_t3));
 
 		for (i = 0; i < 4; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -659,7 +659,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t3[(LWE_N + LWE_N + (LAMBDA / 4) + (LWE_N / 8)) / 8];
 		memcpy((unsigned char*)hash_t3, (unsigned char*)ct, LWE_N + LWE_N + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t3 + LWE_N + LWE_N + (LAMBDA / 4), (unsigned char*)delta, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char*)hash,(unsigned char*)hash_t3, sizeof(hash_t3));
+		sha512((unsigned char*)hash,(unsigned char*)hash_t3, sizeof(hash_t3));
 
 		for (i = 0; i < 4; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -689,7 +689,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t3[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 		memcpy((unsigned char*)hash_t3, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t3 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)sk + LWE_N, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char*)hash, (unsigned char*)hash_t3, sizeof(hash_t3));
+		sha512((unsigned char*)hash, (unsigned char*)hash_t3, sizeof(hash_t3));
 
 		for (i = 0; i < LAMBDA / 32; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);
@@ -706,7 +706,7 @@ int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned ch
 		uint64_t hash_t3[((LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4) + (LWE_N / 8))/8];
 		memcpy((unsigned char*)hash_t3, (unsigned char*)ct, (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4));
 		memcpy((unsigned char*)hash_t3 + (LWE_N * 2) + (LWE_N * 2) + (LAMBDA / 4), (unsigned char*)delta, (LWE_N / 8));
-		crypto_hash_sha512((unsigned char*)hash, (unsigned char*)hash_t3, sizeof(hash_t3));
+		sha512((unsigned char*)hash, (unsigned char*)hash_t3, sizeof(hash_t3));
 
 		for (i = 0; i < LAMBDA / 32; ++i) {
 			ss[i * 8] = (unsigned char)(hash[i] >> 56);

--- a/crypto_kem/sntrup4591761/ref/dec.c
+++ b/crypto_kem/sntrup4591761/ref/dec.c
@@ -9,7 +9,7 @@
 #include "mod3.h"
 #include "rq.h"
 #include "r3.h"
-#include "crypto_hash_sha512.h"
+#include "sha2.h"
 #include "crypto_verify_32.h"
 #include "crypto_kem.h"
 
@@ -65,7 +65,7 @@ int crypto_kem_dec(
   for (i = 0;i < p;++i) result |= modq_nonzero_mask(hr[i] - c[i]);
 
   small_encode(rstr,r);
-  crypto_hash_sha512(hash,rstr,sizeof rstr);
+  sha512(hash,rstr,sizeof rstr);
   result |= crypto_verify_32(hash,cstr);
 
   for (i = 0;i < 32;++i) k[i] = (hash[32 + i] & ~result);

--- a/crypto_kem/sntrup4591761/ref/enc.c
+++ b/crypto_kem/sntrup4591761/ref/enc.c
@@ -8,7 +8,7 @@
 #include "params.h"
 #include "small.h"
 #include "rq.h"
-#include "crypto_hash_sha512.h"
+#include "sha2.h"
 #include "crypto_kem.h"
 
 int crypto_kem_enc(
@@ -37,7 +37,7 @@ int crypto_kem_enc(
 #endif
 
   small_encode(rstr,r);
-  crypto_hash_sha512(hash,rstr,sizeof rstr);
+  sha512(hash,rstr,sizeof rstr);
 
   rq_decode(h,pk);
   rq_mult(c,h,r);


### PR DESCRIPTION
This renames `crypto_hash_sha512` to `sha512`. This makes it more consistent with the `fips202` functions. The header is renamed to `sha2.h`, such that it can also contain other SHA-2 instances. In particular, SHA-384 is added as some NIST submissions use it. It uses the same SUPERCOP C implementation as SHA-512.