### PR TITLE
Turn on Link Time Optimization (-flto)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,80 +156,78 @@ executions is reported in parentheses.
 The following numbers were obtained with `arm-none-eabi-gcc 8.2.0` and libopencm3
 [@8b1ac58](https://github.com/libopencm3/libopencm3/commit/8b1ac585dfd6eb13938f2090bff6a78b836a0452)
 
-
 ### Speed Evaluation
 #### Key Encapsulation Schemes
 | scheme | implementation | key generation [cycles] | encapsulation [cycles] | decapsulation [cycles] |
 | ------ | -------------- | ----------------------- | ---------------------- | -----------------------|
-| frodo640-aes (100 executions) | m4 | AVG: 42,338,468 <br /> MIN: 42,283,346 <br /> MAX: 42,452,566 |  AVG: 46,341,632 <br /> MIN: 46,286,540 <br /> MAX: 46,455,733 | AVG: 47,339,524 <br /> MIN: 47,284,462 <br /> MAX: 47,453,615 |
-| frodo640-cshake (100 executions) | m4 | AVG: 81,293,476 <br /> MIN: 81,293,476 <br /> MAX: 81,293,476 |  AVG: 86,178,252 <br /> MIN: 86,178,252 <br /> MAX: 86,178,252 | AVG: 87,170,982 <br /> MIN: 87,170,982 <br /> MAX: 87,170,982 |
-| frodo640-cshake (100 executions) | opt | AVG: 94,119,511 <br /> MIN: 94,119,511 <br /> MAX: 94,119,511 |  AVG: 106,992,266 <br /> MIN: 106,992,266 <br /> MAX: 106,992,266 | AVG: 107,505,670 <br /> MIN: 107,505,670 <br /> MAX: 107,505,670 |
-| kindi256342 (100 executions) | m4 | AVG: 1,009,667 <br /> MIN: 1,009,667 <br /> MAX: 1,009,667 |  AVG: 1,365,402 <br /> MIN: 1,365,402 <br /> MAX: 1,365,402 | AVG: 1,563,475 <br /> MIN: 1,563,333 <br /> MAX: 1,563,612 |
-| kindi256342 (100 executions) | ref | AVG: 21,794,303 <br /> MIN: 21,777,419 <br /> MAX: 21,812,486 |  AVG: 28,175,792 <br /> MIN: 28,155,214 <br /> MAX: 28,202,159 | AVG: 37,128,741 <br /> MIN: 37,106,492 <br /> MAX: 37,153,861 |
-| kyber1024 (100 executions) | m4 | AVG: 1,771,729 <br /> MIN: 1,770,909 <br /> MAX: 1,772,961 |  AVG: 2,142,912 <br /> MIN: 2,142,092 <br /> MAX: 2,144,145 | AVG: 2,188,917 <br /> MIN: 2,188,098 <br /> MAX: 2,190,149 |
-| kyber1024 (100 executions) | ref | AVG: 2,002,968 <br /> MIN: 2,002,248 <br /> MAX: 2,003,825 |  AVG: 2,527,874 <br /> MIN: 2,527,155 <br /> MAX: 2,528,731 | AVG: 2,728,471 <br /> MIN: 2,727,751 <br /> MAX: 2,729,328 |
-| kyber512 (100 executions) | m4 | AVG: 726,921 <br /> MIN: 726,513 <br /> MAX: 727,657 |  AVG: 987,864 <br /> MIN: 987,456 <br /> MAX: 988,600 | AVG: 1,018,946 <br /> MIN: 1,018,538 <br /> MAX: 1,019,680 |
-| kyber512 (100 executions) | ref | AVG: 847,955 <br /> MIN: 847,469 <br /> MAX: 848,591 |  AVG: 1,205,773 <br /> MIN: 1,205,287 <br /> MAX: 1,206,409 | AVG: 1,330,155 <br /> MIN: 1,329,669 <br /> MAX: 1,330,790 |
-| kyber768 (100 executions) | m4 | AVG: 1,200,291 <br /> MIN: 1,199,710 <br /> MAX: 1,200,930 |  AVG: 1,446,284 <br /> MIN: 1,445,732 <br /> MAX: 1,446,891 | AVG: 1,477,365 <br /> MIN: 1,476,813 <br /> MAX: 1,477,972 |
-| kyber768 (100 executions) | ref | AVG: 1,381,942 <br /> MIN: 1,381,440 <br /> MAX: 1,382,660 |  AVG: 1,748,054 <br /> MIN: 1,747,577 <br /> MAX: 1,748,736 | AVG: 1,904,113 <br /> MIN: 1,903,637 <br /> MAX: 1,904,796 |
-| newhope1024cca (100 executions) | m4 | AVG: 1,243,729 <br /> MIN: 1,243,497 <br /> MAX: 1,244,041 |  AVG: 1,963,184 <br /> MIN: 1,962,952 <br /> MAX: 1,963,495 | AVG: 1,978,982 <br /> MIN: 1,978,748 <br /> MAX: 1,979,293 |
-| newhope1024cca (100 executions) | ref | AVG: 1,508,532 <br /> MIN: 1,508,149 <br /> MAX: 1,508,917 |  AVG: 2,380,428 <br /> MIN: 2,380,046 <br /> MAX: 2,380,813 | AVG: 2,536,341 <br /> MIN: 2,535,957 <br /> MAX: 2,536,725 |
-| ntruhrss701 (10 executions) | m4 | AVG: 161,790,477 <br /> MIN: 161,790,477 <br /> MAX: 161,790,477 |  AVG: 431,668 <br /> MIN: 431,668 <br /> MAX: 431,668 | AVG: 863,053 <br /> MIN: 863,053 <br /> MAX: 863,053 |
-| ntruhrss701 (10 executions) | ref | AVG: 205,156,102 <br /> MIN: 205,156,102 <br /> MAX: 205,156,102 |  AVG: 5,165,764 <br /> MIN: 5,165,764 <br /> MAX: 5,165,764 | AVG: 15,067,346 <br /> MIN: 15,067,346 <br /> MAX: 15,067,346 |
-| ntru-kem-743 (100 executions) | m4 | AVG: 5,663,354 <br /> MIN: 5,423,326 <br /> MAX: 5,807,366 |  AVG: 1,655,116 <br /> MIN: 1,623,221 <br /> MAX: 1,699,419 | AVG: 1,904,374 <br /> MIN: 1,869,697 <br /> MAX: 1,935,083 |
-| ntru-kem-743 (100 executions) | ref | AVG: 59,815,371 <br /> MIN: 59,544,772 <br /> MAX: 60,057,520 |  AVG: 7,539,756 <br /> MIN: 7,512,835 <br /> MAX: 7,578,878 | AVG: 14,229,462 <br /> MIN: 14,211,760 <br /> MAX: 14,276,253 |
-| rlizard-1024-11 (100 executions) | m4 | AVG: 537,225 <br /> MIN: 536,470 <br /> MAX: 538,256 |  AVG: 1,358,408 <br /> MIN: 1,358,259 <br /> MAX: 1,358,544 | AVG: 1,739,881 <br /> MIN: 1,739,729 <br /> MAX: 1,740,012 |
-| rlizard-1024-11 (100 executions) | ref | AVG: 26,423,327 <br /> MIN: 26,422,421 <br /> MAX: 26,424,264 |  AVG: 32,156,356 <br /> MIN: 32,155,918 <br /> MAX: 32,183,476 | AVG: 53,181,411 <br /> MIN: 53,180,957 <br /> MAX: 53,208,533 |
-| saber (10 executions) | m4 | AVG: 949,001 <br /> MIN: 949,001 <br /> MAX: 949,001 |  AVG: 1,231,832 <br /> MIN: 1,231,832 <br /> MAX: 1,231,832 | AVG: 1,259,810 <br /> MIN: 1,259,810 <br /> MAX: 1,259,810 |
-| saber (10 executions) | ref | AVG: 6,530,112 <br /> MIN: 6,530,112 <br /> MAX: 6,530,112 |  AVG: 8,683,792 <br /> MIN: 8,683,792 <br /> MAX: 8,683,792 | AVG: 10,580,822 <br /> MIN: 10,580,822 <br /> MAX: 10,580,822 |
-| sikep751 (1 executions) | ref | AVG: 3,525,565,432 <br /> MIN: 3,525,565,432 <br /> MAX: 3,525,565,432 |  AVG: 5,712,676,148 <br /> MIN: 5,712,676,148 <br /> MAX: 5,712,676,148 | AVG: 6,139,132,015 <br /> MIN: 6,139,132,015 <br /> MAX: 6,139,132,015 |
-| sntrup4591761 (10 executions) | ref | AVG: 145,371,484 <br /> MIN: 145,371,484 <br /> MAX: 145,371,484 |  AVG: 10,331,556 <br /> MIN: 10,331,556 <br /> MAX: 10,331,556 | AVG: 30,335,175 <br /> MIN: 30,335,175 <br /> MAX: 30,335,175 |
-
+| frodo640-aes (100 executions) | m4 | AVG: 41,846,606 <br /> MIN: 41,787,435 <br /> MAX: 41,937,488 |  AVG: 45,858,588 <br /> MIN: 45,799,365 <br /> MAX: 45,949,457 | AVG: 46,798,962 <br /> MIN: 46,739,733 <br /> MAX: 46,889,831 |
+| frodo640-cshake (100 executions) | m4 | AVG: 82,476,011 <br /> MIN: 82,476,011 <br /> MAX: 82,476,011 |  AVG: 85,689,874 <br /> MIN: 85,689,874 <br /> MAX: 85,689,874 | AVG: 86,624,762 <br /> MIN: 86,624,762 <br /> MAX: 86,624,762 |
+| frodo640-cshake (100 executions) | opt | AVG: 94,119,480 <br /> MIN: 94,119,480 <br /> MAX: 94,119,480 |  AVG: 106,992,104 <br /> MIN: 106,992,104 <br /> MAX: 106,992,104 | AVG: 107,505,759 <br /> MIN: 107,505,759 <br /> MAX: 107,505,759 |
+| kindi256342 (100 executions) | m4 | AVG: 1,026,688 <br /> MIN: 1,026,688 <br /> MAX: 1,026,688 |  AVG: 1,389,230 <br /> MIN: 1,389,230 <br /> MAX: 1,389,230 | AVG: 1,597,176 <br /> MIN: 1,597,078 <br /> MAX: 1,597,335 |
+| kindi256342 (100 executions) | ref | AVG: 21,816,330 <br /> MIN: 21,802,624 <br /> MAX: 21,837,728 |  AVG: 28,216,996 <br /> MIN: 28,189,351 <br /> MAX: 28,242,826 | AVG: 37,219,021 <br /> MIN: 37,192,879 <br /> MAX: 37,248,739 |
+| kyber512 (100 executions) | m4 | AVG: 696,215 <br /> MIN: 695,738 <br /> MAX: 696,706 |  AVG: 947,349 <br /> MIN: 946,872 <br /> MAX: 947,840 | AVG: 961,266 <br /> MIN: 960,789 <br /> MAX: 961,757 |
+| kyber512 (100 executions) | ref | AVG: 756,746 <br /> MIN: 756,357 <br /> MAX: 757,127 |  AVG: 1,055,219 <br /> MIN: 1,054,830 <br /> MAX: 1,055,600 | AVG: 1,113,910 <br /> MIN: 1,113,519 <br /> MAX: 1,114,292 |
+| kyber768 (100 executions) | m4 | AVG: 1,144,285 <br /> MIN: 1,143,528 <br /> MAX: 1,144,908 |  AVG: 1,381,476 <br /> MIN: 1,380,756 <br /> MAX: 1,382,070 | AVG: 1,385,304 <br /> MIN: 1,384,585 <br /> MAX: 1,385,896 |
+| kyber768 (100 executions) | ref | AVG: 1,238,703 <br /> MIN: 1,238,136 <br /> MAX: 1,239,336 |  AVG: 1,541,625 <br /> MIN: 1,541,087 <br /> MAX: 1,542,226 | AVG: 1,605,368 <br /> MIN: 1,604,829 <br /> MAX: 1,605,969 |
+| kyber1024 (100 executions) | m4 | AVG: 1,652,185 <br /> MIN: 1,651,399 <br /> MAX: 1,653,033 |  AVG: 2,023,058 <br /> MIN: 2,022,272 <br /> MAX: 2,023,906 | AVG: 2,034,423 <br /> MIN: 2,033,637 <br /> MAX: 2,035,272 |
+| kyber1024 (100 executions) | ref | AVG: 1,778,093 <br /> MIN: 1,777,408 <br /> MAX: 1,778,776 |  AVG: 2,228,046 <br /> MIN: 2,227,361 <br /> MAX: 2,228,729 | AVG: 2,320,356 <br /> MIN: 2,319,670 <br /> MAX: 2,321,040 |
+| newhope1024cca (100 executions) | m4 | AVG: 1,235,521 <br /> MIN: 1,235,153 <br /> MAX: 1,235,809 |  AVG: 1,923,852 <br /> MIN: 1,923,485 <br /> MAX: 1,924,140 | AVG: 1,892,615 <br /> MIN: 1,892,247 <br /> MAX: 1,892,902 |
+| newhope1024cca (100 executions) | ref | AVG: 1,436,932 <br /> MIN: 1,436,509 <br /> MAX: 1,437,293 |  AVG: 2,189,069 <br /> MIN: 2,188,647 <br /> MAX: 2,189,431 | AVG: 2,261,118 <br /> MIN: 2,260,695 <br /> MAX: 2,261,480 |
+| ntru-kem-743 (100 executions) | m4 | AVG: 5,513,013 <br /> MIN: 5,341,611 <br /> MAX: 5,675,846 |  AVG: 1,629,196 <br /> MIN: 1,591,427 <br /> MAX: 1,669,611 | AVG: 1,902,333 <br /> MIN: 1,867,865 <br /> MAX: 1,948,616 |
+| ntru-kem-743 (100 executions) | ref | AVG: 59,894,554 <br /> MIN: 59,721,354 <br /> MAX: 60,160,656 |  AVG: 7,515,874 <br /> MIN: 7,476,052 <br /> MAX: 7,558,060 | AVG: 14,229,136 <br /> MIN: 14,195,830 <br /> MAX: 14,260,475 |
+| ntruhrss701 (100 executions) | m4 | AVG: 169,129,793 <br /> MIN: 169,129,793 <br /> MAX: 169,129,793 |  AVG: 431,191 <br /> MIN: 431,191 <br /> MAX: 431,191 | AVG: 853,802 <br /> MIN: 853,802 <br /> MAX: 853,802 |
+| ntruhrss701 (100 executions) | ref | AVG: 208,848,583 <br /> MIN: 208,848,583 <br /> MAX: 208,848,583 |  AVG: 4,676,473 <br /> MIN: 4,676,473 <br /> MAX: 4,676,473 | AVG: 14,242,562 <br /> MIN: 14,242,562 <br /> MAX: 14,242,562 |
+| rlizard-1024-11 (100 executions) | m4 | AVG: 539,112 <br /> MIN: 537,642 <br /> MAX: 540,116 |  AVG: 1,360,716 <br /> MIN: 1,360,056 <br /> MAX: 1,387,437 | AVG: 1,739,547 <br /> MIN: 1,738,901 <br /> MAX: 1,765,699 |
+| rlizard-1024-11 (100 executions) | ref | AVG: 23,281,057 <br /> MIN: 23,279,547 <br /> MAX: 23,282,695 |  AVG: 32,155,246 <br /> MIN: 32,154,275 <br /> MAX: 32,181,719 | AVG: 58,425,553 <br /> MIN: 58,424,562 <br /> MAX: 58,452,035 |
+| saber (100 executions) | m4 | AVG: 941,256 <br /> MIN: 941,256 <br /> MAX: 941,256 |  AVG: 1,215,987 <br /> MIN: 1,215,987 <br /> MAX: 1,215,987 | AVG: 1,247,622 <br /> MIN: 1,247,622 <br /> MAX: 1,247,622 |
+| saber (100 executions) | ref | AVG: 7,105,821 <br /> MIN: 7,105,821 <br /> MAX: 7,105,821 |  AVG: 8,672,336 <br /> MIN: 8,672,336 <br /> MAX: 8,672,336 | AVG: 10,723,909 <br /> MIN: 10,723,909 <br /> MAX: 10,723,909 |
+| sikep751 (1 executions) | ref | AVG: 3,497,394,974 <br /> MIN: 3,497,394,974 <br /> MAX: 3,497,394,974 |  AVG: 5,659,579,446 <br /> MIN: 5,659,579,446 <br /> MAX: 5,659,579,446 | AVG: 6,083,386,673 <br /> MIN: 6,083,386,673 <br /> MAX: 6,083,386,673 |
+| sntrup4591761 (100 executions) | ref | AVG: 161,480,840 <br /> MIN: 161,480,840 <br /> MAX: 161,480,840 |  AVG: 10,317,864 <br /> MIN: 10,317,864 <br /> MAX: 10,317,864 | AVG: 30,044,806 <br /> MIN: 30,044,806 <br /> MAX: 30,044,806 |
 #### Signature Schemes
 | scheme | implementation | key generation [cycles] | sign [cycles] | verify [cycles] |
 | ------ | -------------- | ----------------------- | ------------- | ----------------|
-| dilithium (100 executions) | m4 | AVG: 2,322,955 <br /> MIN: 2,322,167 <br /> MAX: 2,324,016 |  AVG: 9,978,000 <br /> MIN: 3,141,379 <br /> MAX: 46,351,220 | AVG: 2,322,765 <br /> MIN: 2,322,321 <br /> MAX: 2,323,214 |
-| dilithium (100 executions) | ref | AVG: 2,788,880 <br /> MIN: 2,787,512 <br /> MAX: 2,789,574 |  AVG: 14,561,389 <br /> MIN: 5,042,770 <br /> MAX: 56,392,860 | AVG: 3,064,201 <br /> MIN: 3,063,784 <br /> MAX: 3,064,698 |
-| qTesla-I (100 executions) | ref | AVG: 17,545,901 <br /> MIN: 7,826,320 <br /> MAX: 51,706,602 |  AVG: 6,317,445 <br /> MIN: 1,509,322 <br /> MAX: 25,051,076 | AVG: 1,059,370 <br /> MIN: 1,051,846 <br /> MAX: 1,085,445 |
-| qTesla-III-size (100 executions) | ref | AVG: 58,227,852 <br /> MIN: 22,220,409 <br /> MAX: 159,316,030 |  AVG: 19,869,370 <br /> MIN: 3,457,790 <br /> MAX: 89,902,537 | AVG: 2,297,530 <br /> MIN: 2,292,479 <br /> MAX: 2,325,980 |
-| qTesla-III-speed (100 executions) | ref | AVG: 30,720,411 <br /> MIN: 19,963,698 <br /> MAX: 151,901,043 |  AVG: 11,987,079 <br /> MIN: 3,422,459 <br /> MAX: 46,186,863 | AVG: 2,225,296 <br /> MIN: 2,216,600 <br /> MAX: 2,258,153 |
-| sphincs-shake256-128s (1 executions) | ref | AVG: 4,439,815,208 <br /> MIN: 4,439,815,208 <br /> MAX: 4,439,815,208 |  AVG: 61,665,898,904 <br /> MIN: 61,665,898,904 <br /> MAX: 61,665,898,904 | AVG: 72,326,283 <br /> MIN: 72,326,283 <br /> MAX: 72,326,283 |
+| dilithium (100 executions) | m4 | AVG: 2,237,017 <br /> MIN: 2,235,796 <br /> MAX: 2,237,871 |  AVG: 8,646,941 <br /> MIN: 2,921,035 <br /> MAX: 29,121,483 | AVG: 2,202,950 <br /> MIN: 2,202,621 <br /> MAX: 2,203,261 |
+| dilithium (100 executions) | ref | AVG: 2,582,697 <br /> MIN: 2,582,004 <br /> MAX: 2,583,486 |  AVG: 14,468,471 <br /> MIN: 4,331,420 <br /> MAX: 41,673,197 | AVG: 2,756,490 <br /> MIN: 2,756,134 <br /> MAX: 2,756,765 |
+| qTesla-I (100 executions) | ref | AVG: 17,451,364 <br /> MIN: 7,860,940 <br /> MAX: 44,509,364 |  AVG: 8,427,169 <br /> MIN: 1,539,185 <br /> MAX: 45,442,176 | AVG: 1,129,469 <br /> MIN: 1,120,272 <br /> MAX: 1,158,176 |
+| qTesla-III-size (100 executions) | ref | AVG: 50,234,456 <br /> MIN: 22,120,133 <br /> MAX: 127,099,899 |  AVG: 19,963,056 <br /> MIN: 3,477,360 <br /> MAX: 105,155,974 | AVG: 2,362,085 <br /> MIN: 2,351,144 <br /> MAX: 2,395,126 |
+| qTesla-III-speed (100 executions) | ref | AVG: 32,426,243 <br /> MIN: 19,932,219 <br /> MAX: 76,109,414 |  AVG: 10,107,108 <br /> MIN: 3,464,280 <br /> MAX: 56,183,391 | AVG: 2,328,755 <br /> MIN: 2,316,233 <br /> MAX: 2,354,651 |
+| sphincs-shake256-128s (1 executions) | ref | AVG: 4,366,604,059 <br /> MIN: 4,366,604,059 <br /> MAX: 4,366,604,059 |  AVG: 60,541,692,862 <br /> MIN: 60,541,692,862 <br /> MAX: 60,541,692,862 | AVG: 68,548,057 <br /> MIN: 68,548,057 <br /> MAX: 68,548,057 |
 ### Memory Evaluation
 #### Key Encapsulation Schemes
 | scheme | implementation | key generation [bytes] | encapsulation [bytes] | decapsulation [bytes] |
 | ------ | -------------- | ----------------------- | ---------------------- | -----------------------|
-| frodo640-aes | m4 | 31,116 |  51,444 | 61,820 |
-| frodo640-cshake | m4 | 26,272 |  41,472 | 51,848 |
+| frodo640-aes | m4 | 31,488 |  51,436 | 61,788 |
+| frodo640-cshake | m4 | 26,184 |  41,464 | 51,816 |
 | frodo640-cshake | opt | 36,528 |  58,240 | 68,608 |
-| kindi256342 | m4 | 44,264 |  55,392 | 64,376 |
-| kindi256342 | ref | 59,864 |  71,000 | 84,096 |
-| kyber1024 | m4 | 15,664 |  19,352 | 20,864 |
-| kyber1024 | ref | 15,664 |  19,352 | 20,864 |
-| kyber512 | m4 | 6,456 |  9,120 | 9,928 |
-| kyber512 | ref | 6,456 |  9,120 | 9,928 |
-| kyber768 | m4 | 10,544 |  13,720 | 14,880 |
-| kyber768 | ref | 10,544 |  13,720 | 14,880 |
-| newhope1024cca | m4 | 11,152 |  17,448 | 19,648 |
-| newhope1024cca | ref | 11,152 |  17,448 | 19,648 |
-| ntru-kem-743 | m4 | 25,320 |  23,808 | 28,472 |
-| ntru-kem-743 | ref | 14,148 |  13,372 | 18,036 |
-| ntruhrss701 | m4 | 23,396 |  19,492 | 22,140 |
-| ntruhrss701 | ref | 10,020 |  8,956 | 10,204 |
-| rlizard-1024-11 | m4 | 27,720 |  33,328 | 35,448 |
-| rlizard-1024-11 | ref | 4,272 |  10,532 | 12,636 |
-| saber | m4 | 13,248 |  15,528 | 16,624 |
-| saber | ref | 12,616 |  14,896 | 15,992 |
-| sikep751 | ref | 11,528 |  11,688 | 12,240 |
-| sntrup4591761 | ref | 14,608 |  7,264 | 12,544 |
+| kindi256342 | m4 | 44,240 |  55,280 | 63,904 |
+| kindi256342 | ref | 59,880 |  70,920 | 83,680 |
+| kyber512 | m4 | 6,512 |  9,144 | 12,192 |
+| kyber512 | ref | 6,512 |  9,152 | 12,208 |
+| kyber768 | m4 | 10,600 |  13,744 | 17,816 |
+| kyber768 | ref | 10,600 |  13,752 | 17,832 |
+| kyber1024 | m4 | 15,720 |  19,376 | 24,472 |
+| kyber1024 | ref | 15,720 |  19,384 | 24,488 |
+| newhope1024cca | m4 | 11,160 |  17,456 | 27,896 |
+| newhope1024cca | ref | 11,160 |  17,464 | 27,904 |
+| ntru-kem-743 | m4 | 25,240 |  23,784 | 28,424 |
+| ntru-kem-743 | ref | 14,108 |  13,308 | 17,948 |
+| ntruhrss701 | m4 | 21,964 |  22,108 | 30,524 |
+| ntruhrss701 | ref | 9,552 |  11,072 | 16,688 |
+| rlizard-1024-11 | m4 | 27,720 |  33,320 | 35,440 |
+| rlizard-1024-11 | ref | 4,272 |  10,532 | 12,628 |
+| saber | m4 | 13,216 |  16,544 | 21,192 |
+| saber | ref | 14,232 |  15,968 | 20,616 |
+| sikep751 | ref | 11,752 |  17,328 | 17,424 |
+| sntrup4591761 | ref | 13,072 |  7,288 | 12,568 |
 #### Signature Schemes
 | scheme | implementation | key generation [bytes] | sign [bytes] | verify [bytes] |
 | ------ | -------------- | ----------------------- | ------------- | ----------------|
-| dilithium | m4 | 50,864 |  86,720 | 54,904 |
-| dilithium | ref | 50,864 |  86,720 | 54,904 |
-| qTesla-I | ref | 22,480 |  29,336 | 23,096 |
-| qTesla-III-size | ref | 43,984 |  58,116 | 45,732 |
-| qTesla-III-speed | ref | 43,992 |  58,112 | 45,712 |
-| sphincs-shake256-128s | ref | 2,904 |  3,032 | 10,768 |
+| dilithium | m4 | 50,864 |  87,760 | 54,984 |
+| dilithium | ref | 50,864 |  87,744 | 54,992 |
+| qTesla-I | ref | 22,480 |  29,320 | 23,056 |
+| qTesla-III-size | ref | 43,984 |  58,092 | 45,684 |
+| qTesla-III-speed | ref | 43,992 |  58,092 | 45,668 |
+| sphincs-shake256-128s | ref | 2,928 |  3,456 | 10,992 |
 
 ## Adding new schemes and implementations
 The **pqm4** build system is designed to make it very easy to add new schemes

--- a/benchmarks_to_md.py
+++ b/benchmarks_to_md.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import os
 import numpy as np
+import re
 
 BENCHMARK_DIR = 'benchmarks/'
 
@@ -26,11 +27,25 @@ def formatData(scheme, implementation, data, printStats):
         decverify  = "{:,}".format( max([item[2] for item in data]))
         print("| {} | {} | {} |  {} | {} |".format(scheme, implementation, keygen, encsign, decverify))
 
+
+def sort_mixed(l):
+    r = []
+    for word in l:
+        word = re.split(r'(\d+)', word)
+        for i, fragment in enumerate(word):
+            try:
+                word[i] = int(fragment)  # cast ints for proper sorting
+            except Exception:
+                pass
+        r.append(word)
+    return [''.join(map(str, x)) for x in sorted(r)]
+
+
 def processPrimitives(path, printStats):
     if os.path.exists(path) == False:
         return;
-    for scheme in sorted(os.listdir(path)):
-        for implementation in sorted(os.listdir(path+"/"+scheme)):
+    for scheme in sort_mixed(os.listdir(path)):
+        for implementation in sort_mixed(os.listdir(path+"/"+scheme)):
             measurements = []
             for measurement in os.listdir(path+"/"+scheme+"/"+implementation):
                 with open(path+"/"+scheme+"/"+implementation+"/"+measurement, "r") as f:

--- a/crypto_kem/frodo640-aes/m4/Makefile
+++ b/crypto_kem/frodo640-aes/m4/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 HEADERS = api.h config.h frodo_macrify.h

--- a/crypto_kem/frodo640-aes/ref/Makefile
+++ b/crypto_kem/frodo640-aes/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_kem/frodo640-cshake/m4/Makefile
+++ b/crypto_kem/frodo640-cshake/m4/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 HEADERS = api.h config.h frodo_macrify.h

--- a/crypto_kem/frodo640-cshake/ref/Makefile
+++ b/crypto_kem/frodo640-cshake/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_kem/kindi256342/m4/Makefile
+++ b/crypto_kem/kindi256342/m4/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar 
 
 SOURCES = core.c gen_randomness.c kem.c poly.c poly_encode.c

--- a/crypto_kem/kindi256342/ref/Makefile
+++ b/crypto_kem/kindi256342/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar 
 
 CC_HOST = gcc

--- a/crypto_kem/kyber768/m4/Makefile
+++ b/crypto_kem/kyber768/m4/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 HEADERS = api.h cbd.h indcpa.h ntt.h params.h poly.h polyvec.h reduce.h verify.h

--- a/crypto_kem/kyber768/ref/Makefile
+++ b/crypto_kem/kyber768/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_kem/newhope1024cca/m4/Makefile
+++ b/crypto_kem/newhope1024cca/m4/Makefile
@@ -1,5 +1,5 @@
 CC = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar 
 
 OBJECTS= cpapke.o kem.o newhope_asm.o poly.o precomp.o reduce.o verify.o

--- a/crypto_kem/newhope1024cca/ref/Makefile
+++ b/crypto_kem/newhope1024cca/ref/Makefile
@@ -1,5 +1,5 @@
 CC = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar 
 
 CC_HOST = gcc

--- a/crypto_kem/ntru-kem-743/m4/Makefile
+++ b/crypto_kem/ntru-kem-743/m4/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 OBJECTS= NTRUEncrypt.o kem.o packing.o param.o poly.o

--- a/crypto_kem/ntru-kem-743/ref/Makefile
+++ b/crypto_kem/ntru-kem-743/ref/Makefile
@@ -1,5 +1,5 @@
 CC = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_kem/ntruhrss701/m4/Makefile
+++ b/crypto_kem/ntruhrss701/m4/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_kem/ntruhrss701/ref/Makefile
+++ b/crypto_kem/ntruhrss701/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_kem/rlizard-1024-11/m4/Makefile
+++ b/crypto_kem/rlizard-1024-11/m4/Makefile
@@ -1,5 +1,5 @@
 CC = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 OBJECTS = RLizard.o libkeccak/SP800-185.o libkeccak/KeccakSpongeWidth1600.o libkeccak/KeccakP-1600-inplace-32bi-armv7m-le-gcc.o mult_toom4_1024_16.o 

--- a/crypto_kem/rlizard-1024-11/ref/Makefile
+++ b/crypto_kem/rlizard-1024-11/ref/Makefile
@@ -1,5 +1,5 @@
 CC = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_kem/saber/m4/Makefile
+++ b/crypto_kem/saber/m4/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 HEADERS = api.h cbd.h kem.h pack_unpack.h poly.h poly_mul.h recon.h SABER_indcpa.h SABER_params.h verify.h

--- a/crypto_kem/saber/ref/Makefile
+++ b/crypto_kem/saber/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_kem/sikep751/ref/Makefile
+++ b/crypto_kem/sikep751/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_kem/sntrup4591761/ref/Makefile
+++ b/crypto_kem/sntrup4591761/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_sign/dilithium/m4/Makefile
+++ b/crypto_sign/dilithium/m4/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 HEADERS = api.h params.h sign.h polyvec.h packing.h poly.h reduce.h ntt.h rounding.h

--- a/crypto_sign/dilithium/ref/Makefile
+++ b/crypto_sign/dilithium/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_sign/qTesla-I/ref/Makefile
+++ b/crypto_sign/qTesla-I/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_sign/qTesla-III-size/ref/Makefile
+++ b/crypto_sign/qTesla-III-size/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_sign/qTesla-III-speed/ref/Makefile
+++ b/crypto_sign/qTesla-III-speed/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc

--- a/crypto_sign/sphincs-shake256-128s/ref/Makefile
+++ b/crypto_sign/sphincs-shake256-128s/ref/Makefile
@@ -1,5 +1,5 @@
 CC     = arm-none-eabi-gcc
-CFLAGS = -Wall -Wextra -Wpedantic -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
+CFLAGS = -Wall -Wextra -Wpedantic -O3 -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16 -flto
 AR     = arm-none-eabi-gcc-ar
 
 CC_HOST = gcc


### PR DESCRIPTION
When looking Kyber, I realized that there is a huge penalty for having functions that are small and called very often in a separate file (e.g., modular reductions). Since each .c file is compiled separately, the compiler has no chance to inline those functions. 

Link Time Optimization should solve this problem. By passing the compiler flag `-flto` the compilers puts additional information in the .o files, so that the linker can optimize some stuff. Indeed, for Kyber this yields huge speed ups. 

Over the weekend, I re-benchmarked all schemes in PQM4 compiled with the additional flag `-flto`. 
Here are the results: 
# SPEED
| scheme  | oldCycles | newCycles | speedup |
| ------  | --------- | --------- | ------- |
| frodo640-aes-m4-keyGen  | 42338468 | 41846606 | 1.2%|
| frodo640-aes-m4-encaps  | 46341632 | 45858588 | 1.0%|
| frodo640-aes-m4-decaps  | 47339524 | 46798962 | 1.1%|
| frodo640-cshake-m4-keyGen  | 81293476 | 82476011 | -1.5%|
| frodo640-cshake-m4-encaps  | 86178252 | 85689874 | 0.6%|
| frodo640-cshake-m4-decaps  | 87170982 | 86624762 | 0.6%|
| frodo640-cshake-opt-keyGen  | 94119511 | 94119480 | 0.0%|
| frodo640-cshake-opt-encaps  | 106992266 | 106992104 | 0.0%|
| frodo640-cshake-opt-decaps  | 107505670 | 107505759 | -0.0%|
| kindi256342-m4-keyGen  | 1009667 | 1026688 | -1.7%|
| kindi256342-m4-encaps  | 1365402 | 1389230 | -1.7%|
| kindi256342-m4-decaps  | 1563475 | 1597176 | -2.2%|
| kindi256342-ref-keyGen  | 21794303 | 21816330 | -0.1%|
| kindi256342-ref-encaps  | 28175792 | 28216996 | -0.1%|
| kindi256342-ref-decaps  | 37128741 | 37219021 | -0.2%|
| kyber512-m4-keyGen  | 726921 | 696215 | 4.2%|
| kyber512-m4-encaps  | 987864 | 947349 | 4.1%|
| kyber512-m4-decaps  | 1018946 | 961266 | 5.7%|
| kyber512-ref-keyGen  | 847955 | 756746 | 10.8%|
| kyber512-ref-encaps  | 1205773 | 1055219 | 12.5%|
| kyber512-ref-decaps  | 1330155 | 1113910 | 16.3%|
| kyber768-m4-keyGen  | 1200291 | 1144285 | 4.7%|
| kyber768-m4-encaps  | 1446284 | 1381476 | 4.5%|
| kyber768-m4-decaps  | 1477365 | 1385304 | 6.2%|
| kyber768-ref-keyGen  | 1381942 | 1238703 | 10.4%|
| kyber768-ref-encaps  | 1748054 | 1541625 | 11.8%|
| kyber768-ref-decaps  | 1904113 | 1605368 | 15.7%|
| kyber1024-m4-keyGen  | 1771729 | 1652185 | 6.7%|
| kyber1024-m4-encaps  | 2142912 | 2023058 | 5.6%|
| kyber1024-m4-decaps  | 2188917 | 2034423 | 7.1%|
| kyber1024-ref-keyGen  | 2002968 | 1778093 | 11.2%|
| kyber1024-ref-encaps  | 2527874 | 2228046 | 11.9%|
| kyber1024-ref-decaps  | 2728471 | 2320356 | 15.0%|
| newhope1024cca-m4-keyGen  | 1243729 | 1235521 | 0.7%|
| newhope1024cca-m4-encaps  | 1963184 | 1923852 | 2.0%|
| newhope1024cca-m4-decaps  | 1978982 | 1892615 | 4.4%|
| newhope1024cca-ref-keyGen  | 1508532 | 1436932 | 4.7%|
| newhope1024cca-ref-encaps  | 2380428 | 2189069 | 8.0%|
| newhope1024cca-ref-decaps  | 2536341 | 2261118 | 10.9%|
| ntru-kem-743-m4-keyGen  | 5663354 | 5513013 | 2.7%|
| ntru-kem-743-m4-encaps  | 1655116 | 1629196 | 1.6%|
| ntru-kem-743-m4-decaps  | 1904374 | 1902333 | 0.1%|
| ntru-kem-743-ref-keyGen  | 59815371 | 59894554 | -0.1%|
| ntru-kem-743-ref-encaps  | 7539756 | 7515874 | 0.3%|
| ntru-kem-743-ref-decaps  | 14229462 | 14229136 | 0.0%|
| ntruhrss701-m4-keyGen  | 161790477 | 169129793 | -4.5%|
| ntruhrss701-m4-encaps  | 431668 | 431191 | 0.1%|
| ntruhrss701-m4-decaps  | 863053 | 853802 | 1.1%|
| ntruhrss701-ref-keyGen  | 205156102 | 208848583 | -1.8%|
| ntruhrss701-ref-encaps  | 5165764 | 4676473 | 9.5%|
| ntruhrss701-ref-decaps  | 15067346 | 14242562 | 5.5%|
| rlizard-1024-11-m4-keyGen  | 537225 | 539112 | -0.4%|
| rlizard-1024-11-m4-encaps  | 1358408 | 1360716 | -0.2%|
| rlizard-1024-11-m4-decaps  | 1739881 | 1739547 | 0.0%|
| rlizard-1024-11-ref-keyGen  | 26423327 | 23281057 | 11.9%|
| rlizard-1024-11-ref-encaps  | 32156356 | 32155246 | 0.0%|
| rlizard-1024-11-ref-decaps  | 53181411 | 58425553 | -9.9%|
| saber-m4-keyGen  | 949001 | 941256 | 0.8%|
| saber-m4-encaps  | 1231832 | 1215987 | 1.3%|
| saber-m4-decaps  | 1259810 | 1247622 | 1.0%|
| saber-ref-keyGen  | 6530112 | 7105821 | -8.8%|
| saber-ref-encaps  | 8683792 | 8672336 | 0.1%|
| saber-ref-decaps  | 10580822 | 10723909 | -1.4%|
| sikep751-ref-keyGen  | 3525565432 | 3497394974 | 0.8%|
| sikep751-ref-encaps  | 5712676148 | 5659579446 | 0.9%|
| sikep751-ref-decaps  | 6139132015 | 6083386673 | 0.9%|
| sntrup4591761-ref-keyGen  | 145371484 | 161480840 | -11.1%|
| sntrup4591761-ref-encaps  | 10331556 | 10317864 | 0.1%|
| sntrup4591761-ref-decaps  | 30335175 | 30044806 | 1.0%|
| dilithium-m4-keyGen  | 2322955 | 2237017 | 3.7%|
| dilithium-m4-sign  | 9978000 | 8646941 | 13.3%|
| dilithium-m4-open  | 2322765 | 2202950 | 5.2%|
| dilithium-ref-keyGen  | 2788880 | 2582697 | 7.4%|
| dilithium-ref-sign  | 14561389 | 14468471 | 0.6%|
| dilithium-ref-open  | 3064201 | 2756490 | 10.0%|
| qTesla-I-ref-keyGen  | 17545901 | 17451364 | 0.5%|
| qTesla-I-ref-sign  | 6317445 | 8427169 | -33.4%|
| qTesla-I-ref-open  | 1059370 | 1129469 | -6.6%|
| qTesla-III-size-ref-keyGen  | 58227852 | 50234456 | 13.7%|
| qTesla-III-size-ref-sign  | 19869370 | 19963056 | -0.5%|
| qTesla-III-size-ref-open  | 2297530 | 2362085 | -2.8%|
| qTesla-III-speed-ref-keyGen  | 30720411 | 32426243 | -5.6%|
| qTesla-III-speed-ref-sign  | 11987079 | 10107108 | 15.7%|
| qTesla-III-speed-ref-open  | 2225296 | 2328755 | -4.6%|
| sphincs-shake256-128s-ref-keyGen  | 4439815208 | 4366604059 | 1.6%|
| sphincs-shake256-128s-ref-sign  | 61665898904 | 60541692862 | 1.8%|
| sphincs-shake256-128s-ref-open  | 72326283 | 68548057 | 5.2%|

Unfortunately, for speed there are mixed results. Some schemes get slower, some get faster. Some get faster for one part, but slower for the other. 

# Stack
| scheme  | oldStack  | newStack  | decrease |
| ------  | --------- | --------- | ------- |
| frodo640-aes-m4-keyGen  | 31116 | 31488 | -1.2%|
| frodo640-aes-m4-encaps  | 51444 | 51436 | 0.0%|
| frodo640-aes-m4-decaps  | 61820 | 61788 | 0.1%|
| frodo640-cshake-m4-keyGen  | 26272 | 26184 | 0.3%|
| frodo640-cshake-m4-encaps  | 41472 | 41464 | 0.0%|
| frodo640-cshake-m4-decaps  | 51848 | 51816 | 0.1%|
| frodo640-cshake-opt-keyGen  | 36528 | 36528 | 0.0%|
| frodo640-cshake-opt-encaps  | 58240 | 58240 | 0.0%|
| frodo640-cshake-opt-decaps  | 68608 | 68608 | 0.0%|
| kindi256342-m4-keyGen  | 44264 | 44240 | 0.1%|
| kindi256342-m4-encaps  | 55392 | 55280 | 0.2%|
| kindi256342-m4-decaps  | 64376 | 63904 | 0.7%|
| kindi256342-ref-keyGen  | 59864 | 59880 | -0.0%|
| kindi256342-ref-encaps  | 71000 | 70920 | 0.1%|
| kindi256342-ref-decaps  | 84096 | 83680 | 0.5%|
| kyber512-m4-keyGen  | 6456 | 6512 | -0.9%|
| kyber512-m4-encaps  | 9120 | 9144 | -0.3%|
| kyber512-m4-decaps  | 9928 | 12192 | -22.8%|
| kyber512-ref-keyGen  | 6456 | 6512 | -0.9%|
| kyber512-ref-encaps  | 9120 | 9152 | -0.4%|
| kyber512-ref-decaps  | 9928 | 12208 | -23.0%|
| kyber768-m4-keyGen  | 10544 | 10600 | -0.5%|
| kyber768-m4-encaps  | 13720 | 13744 | -0.2%|
| kyber768-m4-decaps  | 14880 | 17816 | -19.7%|
| kyber768-ref-keyGen  | 10544 | 10600 | -0.5%|
| kyber768-ref-encaps  | 13720 | 13752 | -0.2%|
| kyber768-ref-decaps  | 14880 | 17832 | -19.8%|
| kyber1024-m4-keyGen  | 15664 | 15720 | -0.4%|
| kyber1024-m4-encaps  | 19352 | 19376 | -0.1%|
| kyber1024-m4-decaps  | 20864 | 24472 | -17.3%|
| kyber1024-ref-keyGen  | 15664 | 15720 | -0.4%|
| kyber1024-ref-encaps  | 19352 | 19384 | -0.2%|
| kyber1024-ref-decaps  | 20864 | 24488 | -17.4%|
| newhope1024cca-m4-keyGen  | 11152 | 11160 | -0.1%|
| newhope1024cca-m4-encaps  | 17448 | 17456 | -0.0%|
| newhope1024cca-m4-decaps  | 19648 | 27896 | -42.0%|
| newhope1024cca-ref-keyGen  | 11152 | 11160 | -0.1%|
| newhope1024cca-ref-encaps  | 17448 | 17464 | -0.1%|
| newhope1024cca-ref-decaps  | 19648 | 27904 | -42.0%|
| ntru-kem-743-m4-keyGen  | 25320 | 25240 | 0.3%|
| ntru-kem-743-m4-encaps  | 23808 | 23784 | 0.1%|
| ntru-kem-743-m4-decaps  | 28472 | 28424 | 0.2%|
| ntru-kem-743-ref-keyGen  | 14148 | 14108 | 0.3%|
| ntru-kem-743-ref-encaps  | 13372 | 13308 | 0.5%|
| ntru-kem-743-ref-decaps  | 18036 | 17948 | 0.5%|
| ntruhrss701-m4-keyGen  | 23396 | 21964 | 6.1%|
| ntruhrss701-m4-encaps  | 19492 | 22108 | -13.4%|
| ntruhrss701-m4-decaps  | 22140 | 30524 | -37.9%|
| ntruhrss701-ref-keyGen  | 10020 | 9552 | 4.7%|
| ntruhrss701-ref-encaps  | 8956 | 11072 | -23.6%|
| ntruhrss701-ref-decaps  | 10204 | 16688 | -63.5%|
| rlizard-1024-11-m4-keyGen  | 27720 | 27720 | 0.0%|
| rlizard-1024-11-m4-encaps  | 33328 | 33320 | 0.0%|
| rlizard-1024-11-m4-decaps  | 35448 | 35440 | 0.0%|
| rlizard-1024-11-ref-keyGen  | 4272 | 4272 | 0.0%|
| rlizard-1024-11-ref-encaps  | 10532 | 10532 | 0.0%|
| rlizard-1024-11-ref-decaps  | 12636 | 12628 | 0.1%|
| saber-m4-keyGen  | 13248 | 13216 | 0.2%|
| saber-m4-encaps  | 15528 | 16544 | -6.5%|
| saber-m4-decaps  | 16624 | 21192 | -27.5%|
| saber-ref-keyGen  | 12616 | 14232 | -12.8%|
| saber-ref-encaps  | 14896 | 15968 | -7.2%|
| saber-ref-decaps  | 15992 | 20616 | -28.9%|
| sikep751-ref-keyGen  | 11528 | 11752 | -1.9%|
| sikep751-ref-encaps  | 11688 | 17328 | -48.3%|
| sikep751-ref-decaps  | 12240 | 17424 | -42.4%|
| sntrup4591761-ref-keyGen  | 14608 | 13072 | 10.5%|
| sntrup4591761-ref-encaps  | 7264 | 7288 | -0.3%|
| sntrup4591761-ref-decaps  | 12544 | 12568 | -0.2%|
| dilithium-m4-keyGen  | 50864 | 50864 | 0.0%|
| dilithium-m4-sign  | 86720 | 87760 | -1.2%|
| dilithium-m4-open  | 54904 | 54984 | -0.1%|
| dilithium-ref-keyGen  | 50864 | 50864 | 0.0%|
| dilithium-ref-sign  | 86720 | 87744 | -1.2%|
| dilithium-ref-open  | 54904 | 54992 | -0.2%|
| qTesla-I-ref-keyGen  | 22480 | 22480 | 0.0%|
| qTesla-I-ref-sign  | 29336 | 29320 | 0.1%|
| qTesla-I-ref-open  | 23096 | 23056 | 0.2%|
| qTesla-III-size-ref-keyGen  | 43984 | 43984 | 0.0%|
| qTesla-III-size-ref-sign  | 58116 | 58092 | 0.0%|
| qTesla-III-size-ref-open  | 45732 | 45684 | 0.1%|
| qTesla-III-speed-ref-keyGen  | 43992 | 43992 | 0.0%|
| qTesla-III-speed-ref-sign  | 58112 | 58092 | 0.0%|
| qTesla-III-speed-ref-open  | 45712 | 45668 | 0.1%|
| sphincs-shake256-128s-ref-keyGen  | 2904 | 2928 | -0.8%|
| sphincs-shake256-128s-ref-sign  | 3032 | 3456 | -14.0%|
| sphincs-shake256-128s-ref-open  | 10768 | 10992 | -2.1%|

Stack usage mostly got worse, but not always. The most insane increase, we see for NTRU-HRSS decaps which goes from 10k to 17k.

What do you think? Should we make this a standard option? Should we only turn it on for schemes that benefit from it? 