### PR TITLE
Measure code size

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,8 +233,8 @@ The following numbers were obtained with `arm-none-eabi-gcc 8.2.0` and libopencm
 
 ### Code Size Evaluation
 The code size is evaluated using `arm-none-eabi-size`.
-We subtract the size of the surrounding that is required for setting up the
-board and communicating with the host.
+We subtract the size of the surrounding code that is required for setting up 
+the board and communicating with the host.
 Note that we do not exclude the code size of common dependencies, e.g. Keccak.
 
 #### Key Encapsulation Schemes

--- a/README.md
+++ b/README.md
@@ -231,6 +231,48 @@ The following numbers were obtained with `arm-none-eabi-gcc 8.2.0` and libopencm
 | qTesla-III-speed | ref | 43,992 |  58,112 | 45,712 |
 | sphincs-shake256-128s | ref | 2,904 |  3,032 | 10,768 |
 
+### Code Size Evaluation
+The code size is evaluated using `arm-none-eabi-size`.
+We subtract the size of the surrounding that is required for setting up the
+board and communicating with the host.
+Note that we do not exclude the code size of common dependencies, e.g. Keccak.
+
+#### Key Encapsulation Schemes
+| scheme | implementation | code size [bytes] |
+| ------ | -------------- | ----------------- |
+| frodo640-aes | m4 | 30164 |
+| frodo640-cshake | m4 | 26612 |
+| frodo640-cshake | opt | 24820 |
+| kindi256342 | m4 | 62504 |
+| kindi256342 | ref | 42964 |
+| kyber512 | m4 | 23256 |
+| kyber512 | ref | 16088 |
+| kyber768 | m4 | 23256 |
+| kyber768 | ref | 16088 |
+| kyber1024 | m4 | 23512 |
+| kyber1024 | ref | 16088 |
+| newhope1024cca | m4 | 24024 |
+| newhope1024cca | ref | 22488 |
+| ntru-kem-743 | m4 | 187508 |
+| ntru-kem-743 | ref | 52644 |
+| ntruhrss701 | m4 | 143320 |
+| ntruhrss701 | ref | 17880 |
+| rlizard-1024-11 | m4 | 254432 |
+| rlizard-1024-11 | ref | 70928 |
+| saber | m4 | 55256 |
+| saber | ref | 16344 |
+| sikep751 | ref | 31804 |
+| sntrup4591761 | ref | 45596 |
+#### Signature Schemes
+| scheme | implementation | code size [bytes] |
+| ------ | -------------- | ----------------- |
+| dilithium | m4 | 25292 |
+| dilithium | ref | 20684 |
+| qTesla-III-size | ref | 38028 |
+| qTesla-III-speed | ref | 36684 |
+| qTesla-I | ref | 29324 |
+| sphincs-shake256-128s | ref | 15104 |
+
 ## Adding new schemes and implementations
 The **pqm4** build system is designed to make it very easy to add new schemes
 and implementations, if these implementations follow the NIST/SUPERCOP API. 

--- a/codesize.py
+++ b/codesize.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+import subprocess
+import os
+import re
+
+def getCodeSize(elf):
+  size = subprocess.run(["arm-none-eabi-size", f"elf/{elf}"],
+                            stdout=subprocess.PIPE)
+  sizeBytes = int(str(size.stdout.splitlines()[1]).split("\\t")[3])
+  return sizeBytes
+
+def sort_mixed(l):
+  r = []
+  for word in l:
+      word = re.split(r'(\d+)', word)
+      for i, fragment in enumerate(word):
+          try:
+              word[i] = int(fragment)  # cast ints for proper sorting
+          except Exception:
+              pass
+      r.append(word)
+  return [''.join(map(str, x)) for x in sorted(r)]
+
+def printCodeSizes(primitive):
+  print(f"| scheme | implementation | code size [bytes] |")
+  print(f"| ------ | -------------- | ----------------- |")
+
+  dummyElf  = f"{primitive}_dummy.elf"
+  dummySize = getCodeSize(dummyElf)
+  try:
+    elfs = [x for x in os.listdir('elf') if 'test.elf' in x and primitive in x]
+  except FileNotFoundError:
+    print("There is no elf/ folder. Please first make elfs.")
+    sys.exit(1)
+
+  for elf in sort_mixed(elfs):
+    sizeBytes = getCodeSize(elf)
+    scheme = elf.split("_")[2]
+    impl   = elf.split("_")[3]
+    netCodeSize = sizeBytes - dummySize
+    print(f"| {scheme} | {impl} | {netCodeSize} |")
+
+
+print("### Code Size Evaluation")
+print("#### Key Encapsulation Schemes")
+printCodeSizes("crypto_kem")
+print("## Code Size Evaluation")
+printCodeSizes("crypto_sign")

--- a/codesize.py
+++ b/codesize.py
@@ -44,5 +44,5 @@ def printCodeSizes(primitive):
 print("### Code Size Evaluation")
 print("#### Key Encapsulation Schemes")
 printCodeSizes("crypto_kem")
-print("## Code Size Evaluation")
+print("#### Signature Schemes")
 printCodeSizes("crypto_sign")

--- a/dummy/crypto_kem/api.h
+++ b/dummy/crypto_kem/api.h
@@ -1,0 +1,14 @@
+#ifndef API_H
+#define API_H
+
+#define CRYPTO_SECRETKEYBYTES  1
+#define CRYPTO_PUBLICKEYBYTES  1
+#define CRYPTO_CIPHERTEXTBYTES 1
+#define CRYPTO_BYTES           1
+
+int crypto_kem_keypair(unsigned char *pk, unsigned char *sk);
+int crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk);
+int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned char *sk);
+
+
+#endif

--- a/dummy/crypto_kem/dummy.c
+++ b/dummy/crypto_kem/dummy.c
@@ -1,0 +1,22 @@
+#include "api.h"
+
+int crypto_kem_keypair(unsigned char *pk, unsigned char *sk)
+{
+  (void) pk;
+  (void) sk;
+  return 0;
+}
+int crypto_kem_enc(unsigned char *ct, unsigned char *ss, const unsigned char *pk)
+{
+  (void) ct;
+  (void) ss;
+  (void) pk;
+  return 0;
+}
+int crypto_kem_dec(unsigned char *ss, const unsigned char *ct, const unsigned char *sk)
+{
+  (void) ss;
+  (void) ct;
+  (void) sk;
+  return 0;
+}

--- a/dummy/crypto_sign/api.h
+++ b/dummy/crypto_sign/api.h
@@ -1,0 +1,18 @@
+#ifndef API_H
+#define API_H
+
+#define CRYPTO_PUBLICKEYBYTES 1
+#define CRYPTO_SECRETKEYBYTES 1
+#define CRYPTO_BYTES 1
+
+int crypto_sign_keypair(unsigned char *pk, unsigned char *sk);
+
+int crypto_sign(unsigned char *sm, unsigned long long *smlen,
+                const unsigned char *msg, unsigned long long len,
+                const unsigned char *sk);
+
+int crypto_sign_open(unsigned char *m, unsigned long long *mlen,
+                     const unsigned char *sm, unsigned long long smlen,
+                     const unsigned char *pk);
+
+#endif

--- a/dummy/crypto_sign/dummy.c
+++ b/dummy/crypto_sign/dummy.c
@@ -1,0 +1,32 @@
+#include "api.h"
+
+int crypto_sign_keypair(unsigned char *pk, unsigned char *sk)
+{
+  (void) pk;
+  (void) sk;
+  return 0;
+}
+
+int crypto_sign(unsigned char *sm, unsigned long long *smlen,
+                const unsigned char *msg, unsigned long long len,
+                const unsigned char *sk)
+{
+  (void) sm;
+  (void) smlen;
+  (void) msg;
+  (void) len;
+  (void) sk;
+  return 0;
+}
+
+int crypto_sign_open(unsigned char *m, unsigned long long *mlen,
+                     const unsigned char *sm, unsigned long long smlen,
+                     const unsigned char *pk)
+{
+  (void) m;
+  (void) mlen;
+  (void) sm;
+  (void) smlen;
+  (void) pk;
+  return 0;
+}


### PR DESCRIPTION
I added a script that measures the code size of each scheme. 

I wanted to exclude our own code (libopencm3, calling code, serial communication), so 
I created dummy schemes that do nothing at all and subtracted that. 

Dependencies (e.g., Keccak) are still included in the code size of the implementations. 

Could someone have a look if this makes any sense? 
The only paper that lists code size for some of our implementations that I'm currently aware of is [1], but these numbers are quite different. Note that they do not include Keccak, but that doesn't fully explain the differences. 
 

[1] https://round5.org/doc/r5m4text.pdf