### PR TITLE
Shrink RAM from 128 KiB to 112 KiB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OPENCM3DIR  = ./libopencm3
 OPENCM3NAME = opencm3_stm32f4
 OPENCM3FILE = $(OPENCM3DIR)/lib/lib$(OPENCM3NAME).a
-LDSCRIPT    = $(OPENCM3DIR)/lib/stm32/f4/stm32f405x6.ld
+LDSCRIPT    = stm32f405x6.ld
 
 PREFIX     ?= arm-none-eabi
 CC          = $(PREFIX)-gcc

--- a/stm32f405x6.ld
+++ b/stm32f405x6.ld
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the libopencm3 project.
+ *
+ * Copyright (C) 2009 Uwe Hermann <uwe@hermann-uwe.de>
+ * Copyright (C) 2011 Stephen Caudle <scaudle@doceme.com>
+ * Copyright (C) 2013 Sergey Krukowski <softsr@yahoo.de>
+ *
+ * This library is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* Linker script for the STM32F40xxG chip (1024K flash, 128K RAM). */
+
+/* Define memory regions. */
+MEMORY
+{
+	rom (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 112K
+	ccm (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+}
+
+/* Include the common ld script. */
+INCLUDE cortex-m-generic.ld
+


### PR DESCRIPTION
By not using SRAM2 we get more consistent benchmarks since SRAM2 seems to slow
down memory accesses. This lead to schemes that are wasteful with stack
(i.e., overflowing the 16 KiB SRAM2 into SRAM1) were faster.