### PR TITLE
Update mupq/pqclean and port the opaque structs for the hashing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,24 +173,43 @@ new subdirectory under `crypto_sign/`.
    from all KEM and signature implementations. 
    Functions from the FIPS202 standard (and related publication SP 800-185) are defined in `mupq/common/fips202.h` as follows:
    ```c
-  void shake128_absorb(uint64_t *state, const unsigned char *input, unsigned int inlen);
-  void shake128_squeezeblocks(unsigned char *output, unsigned long long nblocks, uint64_t *state);
-  void shake128(unsigned char *output, unsigned long long outlen, const unsigned char *input,  unsigned long long inlen);
+  void shake128_absorb(shake128ctx *state, const uint8_t *input, size_t inlen);
+  void shake128_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state);
+  void shake128(uint8_t *output, size_t outlen, const uint8_t *input, size_t inlen);
 
-  void cshake128_simple_absorb(uint64_t *state, uint16_t cstm, const unsigned char *in, unsigned long long inlen);
-  void cshake128_simple_squeezeblocks(unsigned char *output, unsigned long long nblocks, uint64_t *state);
-  void cshake128_simple(unsigned char *output, unsigned long long outlen, uint16_t cstm, const unsigned char *in, unsigned long long inlen);
+  void shake128_inc_init(shake128incctx *state);
+  void shake128_inc_absorb(shake128incctx *state, const uint8_t *input, size_t inlen);
+  void shake128_inc_finalize(shake128incctx *state);
+  void shake128_inc_squeeze(uint8_t *output, size_t outlen, shake128incctx *state);
 
-  void shake256_absorb(uint64_t *state, const unsigned char *input, unsigned int inlen);
-  void shake256_squeezeblocks(unsigned char *output, unsigned long long nblocks, uint64_t *state);
-  void shake256(unsigned char *output, unsigned long long outlen, const unsigned char *input,  unsigned long long inlen);
+  void cshake128_simple_absorb(shake128ctx *state, uint16_t cstm, const uint8_t *input, size_t inlen);
+  void cshake128_simple_squeezeblocks(uint8_t *output, size_t nblocks, shake128ctx *state);
+  void cshake128_simple(uint8_t *output, size_t outlen, uint16_t cstm, const uint8_t *input, size_t inlen);
 
-  void cshake256_simple_absorb(uint64_t *state, uint16_t cstm, const unsigned char *in, unsigned long long inlen);
-  void cshake256_simple_squeezeblocks(unsigned char *output, unsigned long long nblocks, uint64_t *state);
-  void cshake256_simple(unsigned char *output, unsigned long long outlen, uint16_t cstm, const unsigned char *in, unsigned long long inlen);
+  void shake256_absorb(shake256ctx *state, const uint8_t *input, size_t inlen);
+  void shake256_squeezeblocks(uint8_t *output, size_t nblocks, shake256ctx *state);
+  void shake256(uint8_t *output, size_t outlen, const uint8_t *input, size_t inlen);
 
-  void sha3_256(unsigned char *output, const unsigned char *input,  unsigned long long inlen);
-  void sha3_512(unsigned char *output, const unsigned char *input,  unsigned long long inlen);
+  void shake256_inc_init(shake256incctx *state);
+  void shake256_inc_absorb(shake256incctx *state, const uint8_t *input, size_t inlen);
+  void shake256_inc_finalize(shake256incctx *state);
+  void shake256_inc_squeeze(uint8_t *output, size_t outlen, shake256incctx *state);
+
+  void cshake256_simple_absorb(shake256ctx *state, uint16_t cstm, const uint8_t *input, size_t inlen);
+  void cshake256_simple_squeezeblocks(uint8_t *output, size_t nblocks, shake256ctx *state);
+  void cshake256_simple(uint8_t *output, size_t outlen, uint16_t cstm, const uint8_t *input, size_t inlen);
+
+  void sha3_256_inc_init(sha3_256incctx *state);
+  void sha3_256_inc_absorb(sha3_256incctx *state, const uint8_t *input, size_t inlen);
+  void sha3_256_inc_finalize(uint8_t *output, sha3_256incctx *state);
+
+  void sha3_256(uint8_t *output, const uint8_t *input, size_t inlen);
+
+  void sha3_512_inc_init(sha3_512incctx *state);
+  void sha3_512_inc_absorb(sha3_512incctx *state, const uint8_t *input, size_t inlen);
+  void sha3_512_inc_finalize(uint8_t *output, sha3_512incctx *state);
+
+  void sha3_512(uint8_t *output, const uint8_t *input, size_t inlen);
    ```
    Implementations that want to make use of these optimized routines simply include 
    `fips202.h`. The API for `sha3_256` and `sha3_512` follows the 
@@ -198,6 +217,7 @@ new subdirectory under `crypto_sign/`.
    The API for `shake256` and `shake512` is very similar, except that it supports variable-length output.
    The SHAKE and cSHAKE functions are also accessible via the absorb-squeezeblocks functions, which offer incremental
    output generation (but not incremental input handling).
+   The variants with `_inc_` offer both incremental input handling and output generation.
 
 ## Using optimized SHA-2
 
@@ -211,24 +231,24 @@ new subdirectory under `crypto_sign/`.
   We've therefore decided to only include a C version of the SHA-2 variants.
   The available functions are:
    ```c
-  void sha224_inc_init(uint8_t *state);
-  void sha224_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks);
-  void sha224_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen);
+  void sha224_inc_init(sha224ctx *state);
+  void sha224_inc_blocks(sha224ctx *state, const uint8_t *in, size_t inblocks);
+  void sha224_inc_finalize(uint8_t *out, sha224ctx *state, const uint8_t *in, size_t inlen);
   void sha224(uint8_t *out, const uint8_t *in, size_t inlen);
 
-  void sha256_inc_init(uint8_t *state);
-  void sha256_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks);
-  void sha256_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen);
+  void sha256_inc_init(sha256ctx *state);
+  void sha256_inc_blocks(sha256ctx *state, const uint8_t *in, size_t inblocks);
+  void sha256_inc_finalize(uint8_t *out, sha256ctx *state, const uint8_t *in, size_t inlen);
   void sha256(uint8_t *out, const uint8_t *in, size_t inlen);
 
-  void sha384_inc_init(uint8_t *state);
-  void sha384_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks);
-  void sha384_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen);
+  void sha384_inc_init(sha384ctx *state);
+  void sha384_inc_blocks(sha384ctx *state, const uint8_t *in, size_t inblocks);
+  void sha384_inc_finalize(uint8_t *out, sha384ctx *state, const uint8_t *in, size_t inlen);
   void sha384(uint8_t *out, const uint8_t *in, size_t inlen);
 
-  void sha512_inc_init(uint8_t *state);
-  void sha512_inc_blocks(uint8_t *state, const uint8_t *in, size_t inblocks);
-  void sha512_inc_finalize(uint8_t *out, uint8_t *state, const uint8_t *in, size_t inlen);
+  void sha512_inc_init(sha512ctx *state);
+  void sha512_inc_blocks(sha512ctx *state, const uint8_t *in, size_t inblocks);
+  void sha512_inc_finalize(uint8_t *out, sha512ctx *state, const uint8_t *in, size_t inlen);
   void sha512(uint8_t *out, const uint8_t *in, size_t inlen);
   ```
   Implementations can use these by including `sha2.h`.

--- a/crypto_kem/kyber768/m4/symmetric-fips202.c
+++ b/crypto_kem/kyber768/m4/symmetric-fips202.c
@@ -8,12 +8,12 @@
 *
 * Description: Absorb step of the SHAKE128 specialized for the Kyber context.
 *
-* Arguments:   - uint64_t *s:                     pointer to (uninitialized) output Keccak state
+* Arguments:   - shake128ctx *s:                  pointer to (uninitialized) output Keccak state
 *              - const unsigned char *input:      pointer to KYBER_SYMBYTES input to be absorbed into s
 *              - unsigned char i                  additional byte of input
 *              - unsigned char j                  additional byte of input
 **************************************************/
-void kyber_shake128_absorb(keccak_state *s, const unsigned char *input, unsigned char x, unsigned char y) {
+void kyber_shake128_absorb(shake128ctx *s, const unsigned char *input, unsigned char x, unsigned char y) {
     unsigned char extseed[KYBER_SYMBYTES + 2];
     int i;
 
@@ -22,7 +22,7 @@ void kyber_shake128_absorb(keccak_state *s, const unsigned char *input, unsigned
     }
     extseed[i++] = x;
     extseed[i]   = y;
-    shake128_absorb(s->s, extseed, KYBER_SYMBYTES + 2);
+    shake128_absorb(s, extseed, KYBER_SYMBYTES + 2);
 }
 
 /*************************************************
@@ -34,10 +34,10 @@ void kyber_shake128_absorb(keccak_state *s, const unsigned char *input, unsigned
 *
 * Arguments:   - unsigned char *output:      pointer to output blocks
 *              - size_t nblocks:             number of blocks to be squeezed (written to output)
-*              - keccak_state *s:            pointer to in/output Keccak state
+*              - shake128ctx *s:            pointer to in/output Keccak state
 **************************************************/
-void kyber_shake128_squeezeblocks(unsigned char *output, size_t nblocks, keccak_state *s) {
-    shake128_squeezeblocks(output, nblocks, s->s);
+void kyber_shake128_squeezeblocks(unsigned char *output, size_t nblocks, shake128ctx *s) {
+    shake128_squeezeblocks(output, nblocks, s);
 }
 
 /*************************************************

--- a/crypto_kem/kyber768/m4/symmetric.h
+++ b/crypto_kem/kyber768/m4/symmetric.h
@@ -5,12 +5,8 @@
 #include "params.h"
 #include <stddef.h>
 
-typedef struct {
-    uint64_t s[25];
-} keccak_state;
-
-void kyber_shake128_absorb(keccak_state *s, const unsigned char *input, unsigned char x, unsigned char y);
-void kyber_shake128_squeezeblocks(unsigned char *output, size_t nblocks, keccak_state *s);
+void kyber_shake128_absorb(shake128ctx *s, const unsigned char *input, unsigned char x, unsigned char y);
+void kyber_shake128_squeezeblocks(unsigned char *output, size_t nblocks, shake128ctx *s);
 void shake256_prf(unsigned char *output, size_t outlen, const unsigned char *key, unsigned char nonce);
 
 #define hash_h(OUT, IN, INBYTES) sha3_256(OUT, IN, INBYTES)
@@ -22,6 +18,6 @@ void shake256_prf(unsigned char *output, size_t outlen, const unsigned char *key
 
 #define XOF_BLOCKBYTES 168
 
-typedef keccak_state xof_state;
+typedef shake128ctx xof_state;
 
 #endif /* SYMMETRIC_H */

--- a/crypto_kem/newhope1024cca/m4/poly.c
+++ b/crypto_kem/newhope1024cca/m4/poly.c
@@ -202,7 +202,7 @@ void poly_tomsg(unsigned char *msg, const poly *x) {
 void poly_uniform(poly *a, const unsigned char *seed) {
     unsigned int ctr = 0;
     uint16_t val;
-    uint64_t state[25];
+    shake128ctx state;
     uint8_t buf[SHAKE128_RATE];
     uint8_t extseed[NEWHOPE_SYMBYTES + 1];
     int i, j;
@@ -214,9 +214,9 @@ void poly_uniform(poly *a, const unsigned char *seed) {
     for (i = 0; i < NEWHOPE_N / 64; i++) { /* generate a in blocks of 64 coefficients */
         ctr = 0;
         extseed[NEWHOPE_SYMBYTES] = (unsigned char) i; /* domain-separate the 16 independent calls */
-        shake128_absorb(state, extseed, NEWHOPE_SYMBYTES + 1);
+        shake128_absorb(&state, extseed, NEWHOPE_SYMBYTES + 1);
         while (ctr < 64) { /* Very unlikely to run more than once */
-            shake128_squeezeblocks(buf, 1, state);
+            shake128_squeezeblocks(buf, 1, &state);
             for (j = 0; j < SHAKE128_RATE && ctr < 64; j += 2) {
                 val = (buf[j] | ((uint16_t) buf[j + 1] << 8));
                 if (val < 5 * NEWHOPE_Q) {

--- a/crypto_kem/newhope1024cpa/m4/poly.c
+++ b/crypto_kem/newhope1024cpa/m4/poly.c
@@ -202,7 +202,7 @@ void poly_tomsg(unsigned char *msg, const poly *x) {
 void poly_uniform(poly *a, const unsigned char *seed) {
     unsigned int ctr = 0;
     uint16_t val;
-    uint64_t state[25];
+    shake128ctx state;
     uint8_t buf[SHAKE128_RATE];
     uint8_t extseed[NEWHOPE_SYMBYTES + 1];
     int i, j;
@@ -214,9 +214,9 @@ void poly_uniform(poly *a, const unsigned char *seed) {
     for (i = 0; i < NEWHOPE_N / 64; i++) { /* generate a in blocks of 64 coefficients */
         ctr = 0;
         extseed[NEWHOPE_SYMBYTES] = (unsigned char) i; /* domain-separate the 16 independent calls */
-        shake128_absorb(state, extseed, NEWHOPE_SYMBYTES + 1);
+        shake128_absorb(&state, extseed, NEWHOPE_SYMBYTES + 1);
         while (ctr < 64) { /* Very unlikely to run more than once */
-            shake128_squeezeblocks(buf, 1, state);
+            shake128_squeezeblocks(buf, 1, &state);
             for (j = 0; j < SHAKE128_RATE && ctr < 64; j += 2) {
                 val = (buf[j] | ((uint16_t) buf[j + 1] << 8));
                 if (val < 5 * NEWHOPE_Q) {


### PR DESCRIPTION
PQClean introduced a different API for hashing with an opaque state struct. This PR ports that into pqm4 and updates the relevant schemes to use that API.

I assume that the impact on benchmarks is zero or negligible.

This resolves #88.