### PR TITLE
Don't use any sed flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ DEST_HOST=bin-host
 DEST=bin
 
 TARGET_NAME = $(shell echo $(IMPLEMENTATION_PATH) | sed 's@/@_@g')
-TYPE = $(shell echo $(IMPLEMENTATION_PATH) | sed -r 's@(.*/)?crypto_(kem|sign)(/.*)@\2@')
+TYPE = $(shell echo $(IMPLEMENTATION_PATH) | sed 's@^\([^/]*/\)*crypto_\([^/]*\)/.*$$@\2@')
 IMPLEMENTATION_SOURCES = $(wildcard $(IMPLEMENTATION_PATH)/*.c) $(wildcard $(IMPLEMENTATION_PATH)/*.s) $(wildcard $(IMPLEMENTATION_PATH)/*.S)
 IMPLEMENTATION_HEADERS = $(IMPLEMENTATION_PATH)/*.h
 


### PR DESCRIPTION
In #105 an issue was encountered with `sed -r`. This is a GNU-specific option to enable ERE, which may be called `-E` with `sed` in BSD/macOS. While GNU `sed` also supports `-E` (not sure which versions), we may as well completely avoid all of this by sticking to POSIX BRE.

This expression doesn't match exactly the same, but I believe it should work everywhere.