### PR TITLE
Fix hal_get_time()

### DIFF
--- a/common/hal-stm32f4.c
+++ b/common/hal-stm32f4.c
@@ -63,9 +63,8 @@ static void usart_setup(int baud)
 
 static void systick_setup(void)
 {
-  // assumes clock_setup was called with CLOCK_BENCHMARK
   systick_set_clocksource(STK_CSR_CLKSOURCE_AHB);
-  systick_set_reload(2399999);
+  systick_set_reload(16777215);
   systick_interrupt_enable();
   systick_counter_enable();
 }
@@ -91,12 +90,18 @@ void hal_send_str(const char* in)
   send_USART_str(in);
 }
 
-static unsigned long long overflowcnt = 0;
+static volatile unsigned long long overflowcnt = 0;
 void sys_tick_handler(void)
 {
   ++overflowcnt;
 }
 uint64_t hal_get_time()
 {
-  return (overflowcnt+1)*2400000llu - systick_get_value();
+  while (true) {
+    unsigned long long before = overflowcnt;
+    unsigned long long result = (before + 1) * 16777216llu - systick_get_value();
+    if (overflowcnt == before) {
+      return result;
+    }
+  }
 }


### PR DESCRIPTION
`hal_get_time()` gave wrong values if the SysTick counter reached 0 between reading `overflowcnt` and calling `systick_get_value()`. This behavior is now addressed by retrying if that happens. Thanks to djb for pointing that out to us.

The reset value is also increased to the maximum of 2^24-1, such that there is less overhead from the interrupt handler, and overflowcnt is marked `volatile` to ensure correctness.