### PR TITLE
Add missing fields in benchmarkclock struct

### DIFF
--- a/common/hal-stm32f4.c
+++ b/common/hal-stm32f4.c
@@ -15,10 +15,13 @@ const struct rcc_clock_scale benchmarkclock = {
   .plln = 192, //VCOout = VCOin * PLLN = 192 MHz
   .pllp = 8, //PLLCLK = VCOout / PLLP = 24 MHz (low to have 0WS)
   .pllq = 4, //PLL48CLK = VCOout / PLLQ = 48 MHz (required for USB, RNG)
+  .pllr = 0,
   .hpre = RCC_CFGR_HPRE_DIV_NONE,
   .ppre1 = RCC_CFGR_PPRE_DIV_2,
   .ppre2 = RCC_CFGR_PPRE_DIV_NONE,
+  .voltage_scale = PWR_SCALE1,
   .flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_0WS,
+  .ahb_frequency = 24000000,
   .apb1_frequency = 12000000,
   .apb2_frequency = 24000000,
 };


### PR DESCRIPTION
The missing fields are initialized with default values following
the conventions of the predefined profiles from
<https://libopencm3.org/docs/latest/stm32f4/html/rcc_8c_source.html>.

I did not test this patch on the M4 hardware.

This PR resolved issue #117 .