### PR TITLE
Update mupq

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -52,6 +52,8 @@ class M4Settings(mupq.PlatformSettings):
         {'scheme': 'rainbowVc-classic', 'implementation': 'clean'},
         {'scheme': 'rainbowVc-cyclic', 'implementation': 'clean'},
         {'scheme': 'rainbowVc-cyclic-compressed', 'implementation': 'clean'},
+        {'scheme': 'qtesla-p-I', 'implementation': 'clean'},
+        {'scheme': 'qtesla-p-III', 'implementation': 'clean'},
     )
 
 


### PR DESCRIPTION
https://github.com/mupq/mupq/pull/34 refactors our number printing to reduce code size. For pqm4 this does not matter that much, but let's keep it in sync with mupq. Our code benchmarks exclude this common code, so there is no need to update those numbers.

This also pulls in a newer version of PQClean, which now includes qTesla (https://github.com/PQClean/PQClean/pull/239)
Unfortunately, qtesla-I-p needs 174.5 KiB and qtesla-p-III needs 403.2 KiB of RAM, so it does not fit on our platform.
#53 