### PR TITLE
len and flag were flipped

### DIFF
--- a/crypto_kem/r5nd-1kemcca-5d/m4/ct_util.c
+++ b/crypto_kem/r5nd-1kemcca-5d/m4/ct_util.c
@@ -21,7 +21,7 @@ uint8_t ct_memcmp(const void *a, const void *b, size_t len)
 
 // conditional move; overwrite d with a if flag is nonzero
 
-void ct_cmov(void *d, const void * a, uint8_t flag, size_t len)
+void ct_cmov(void *d, const void * a, size_t len, uint8_t flag)
 {
     uint8_t *d8 = (uint8_t *) d;
     const uint8_t *a8 = (const uint8_t *) a;

--- a/crypto_kem/r5nd-1kemcca-5d/m4/ct_util.h
+++ b/crypto_kem/r5nd-1kemcca-5d/m4/ct_util.h
@@ -13,6 +13,6 @@
 uint8_t ct_memcmp(const void *a, const void *b, size_t len);
 
 //  conditional move; overwrite d with a if flag is nonzero
-void ct_cmov(void *d, const void * a, uint8_t flag, size_t len);
+void ct_cmov(void *d, const void * a, size_t len, uint8_t flag);
 
 #endif /* _CT_UTIL_H_ */


### PR DESCRIPTION
Hello,

ref. https://github.com/r5embed/r5embed/commit/71929f9c0b706d8193dcb31ba1214372d38fdcbe

The two last parameters in definition of` ct_cmov()` were flipped. The conditional move is only used in `r5_cca_kem_decapsulate()`, line 99 of r5_cca_kem.c:
```c
    ct_cmov(hash_in, sk + PARAMS_KAPPA_BYTES, PARAMS_KAPPA_BYTES, fail);
```
This didn't break applications but implication was that CCA was not really CCA. The NIST submitted code does not appear to have this bug.

Cheers,
- markku