### PR TITLE
Update to the most recent version of libopencm3

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,8 @@ For most schemes we report minimum, maximum, and average cycle counts of 100 exe
 For some particularly slow schemes we reduce the number of executions; the number of
 executions is reported in parentheses.
 
-The numbers were obtained with `arm-none-eabi-gcc 9.1.0` and libopencm3
-[@8b1ac58](https://github.com/libopencm3/libopencm3/commit/8b1ac585dfd6eb13938f2090bff6a78b836a0452).
+The numbers were obtained with `arm-none-eabi-gcc 9.1.0` or `9.2.0`. 
+The performance differences between those versions are negligible.
 
 The code-size measurements only include the code that is provided by the scheme implementation, i.e., exclude common code like hashing or C standard library functions.
 The measurements are performed with `arm-none-eabi-size`.

--- a/common/hal-stm32f4.c
+++ b/common/hal-stm32f4.c
@@ -19,6 +19,7 @@ const struct rcc_clock_scale benchmarkclock = {
   .hpre = RCC_CFGR_HPRE_DIV_NONE,
   .ppre1 = RCC_CFGR_PPRE_DIV_2,
   .ppre2 = RCC_CFGR_PPRE_DIV_NONE,
+  .pll_source = RCC_CFGR_PLLSRC_HSE_CLK,
   .voltage_scale = PWR_SCALE1,
   .flash_config = FLASH_ACR_DCEN | FLASH_ACR_ICEN | FLASH_ACR_LATENCY_0WS,
   .ahb_frequency = 24000000,
@@ -31,11 +32,11 @@ static void clock_setup(const enum clock_mode clock)
   switch(clock)
   {
     case CLOCK_BENCHMARK:
-      rcc_clock_setup_hse_3v3(&benchmarkclock);
+      rcc_clock_setup_pll(&benchmarkclock);
       break;
     case CLOCK_FAST:
     default:
-      rcc_clock_setup_hse_3v3(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
+      rcc_clock_setup_pll(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
       break;
   }
 


### PR DESCRIPTION
As new is always better, I've updated libopencm3. 

In https://github.com/libopencm3/libopencm3/commit/ca6dcfbea137bd2145b4a7fbf24379f565f8280d libopencm3 slightly changed the clock setup so we need to adjust that as well.
As all changes are in the clock setup, this does not affect benchmark results at all.