### PR TITLE
Take clean CPA three bears from PQClean

### DIFF
--- a/benchmarks.csv
+++ b/benchmarks.csv
@@ -3,8 +3,8 @@ Key Encapsulation Schemes,,,,,,,,,,
 Scheme,Implementation,Key Generation [cycles] (mean),Key Generation [cycles] (min),Key Generation [cycles] (max),Encapsulation [cycles] (mean),Encapsulation [cycles] (min),Encapsulation [cycles] (max),Decapsulation [cycles] (mean),Decapsulation [cycles] (min),Decapsulation [cycles] (max)
 babybear (100 executions),clean,4031805,4031805,4031805,5878092,5878092,5878092,11997012,11997012,11997012
 babybear (100 executions),opt,596665,596665,596665,752117,752117,752117,1142773,1142773,1142773
+babybear-ephem (100 executions),clean,4031806,4031806,4031806,5905062,5905062,5905062,1998296,1998296,1998296
 babybear-ephem (100 executions),opt,596664,596664,596664,767860,767860,767860,231728,231728,231728
-babybear-ephem (100 executions),ref,3968935,3968935,3968935,5817861,5817861,5817861,1948755,1948755,1948755
 firesaber (100 executions),clean,3816702,3816702,3816702,4743325,4743325,4743325,5355474,5355474,5355474
 firesaber (100 executions),m4,1448776,1448776,1448776,1786930,1786930,1786930,1853339,1853339,1853339
 frodokem640aes (100 executions),m4,47050559,47050559,47050559,45883334,45883334,45883334,45366065,45366065,45366065
@@ -29,8 +29,8 @@ lightsaber (100 executions),clean,1051133,1051133,1051133,1537170,1537170,153717
 lightsaber (100 executions),m4,459965,459965,459965,651273,651273,651273,678810,678810,678810
 mamabear (100 executions),clean,8861427,8861427,8861427,11598380,11598380,11598380,23520327,23520327,23520327
 mamabear (100 executions),opt,1195048,1195048,1195048,1402955,1402955,1402955,1955496,1955496,1955496
+mamabear-ephem (100 executions),clean,8870888,8870888,8870888,11637666,11637666,11637666,2938885,2938885,2938885
 mamabear-ephem (100 executions),opt,1206350,1206350,1206350,1431341,1431341,1431341,320233,320233,320233
-mamabear-ephem (100 executions),ref,8783565,8783565,8783565,11525870,11525870,11525870,2876105,2876105,2876105
 newhope1024cca (100 executions),clean,1460167,1459836,1460406,2264773,2264441,2265011,2410906,2410574,2411144
 newhope1024cca (100 executions),m4,1157677,1157321,1158018,1688875,1688519,1689216,1614268,1613912,1614609
 newhope1024cpa (100 executions),clean,1274813,1274572,1275142,1857055,1856813,1857383,327778,327778,327778
@@ -52,8 +52,8 @@ ntrulpr761 (100 executions),ref,74265583,74265583,74265583,147846761,147846761,1
 ntrulpr857 (100 executions),ref,94016969,94016969,94016969,187235730,187235730,187235730,280075965,280075965,280075965
 papabear (100 executions),clean,15587475,15587475,15587475,19220187,19220187,19220187,38837350,38837350,38837350
 papabear (100 executions),opt,2014216,2014216,2014216,2276138,2276138,2276138,3000239,3000239,3000239
+papabear-ephem (100 executions),clean,15601295,15601295,15601295,19261570,19261570,19261570,3879464,3879464,3879464
 papabear-ephem (100 executions),opt,2029284,2029284,2029284,2308148,2308148,2308148,411623,411623,411623
-papabear-ephem (100 executions),ref,15490269,15490269,15490269,19126020,19126020,19126020,3803444,3803444,3803444
 r5n1-1kemcca-0d (100 executions),m4,3468700,3452036,3487229,3311885,3287627,3335808,3791981,3762550,3826612
 r5n1-1kemcca-0d (100 executions),opt,3275672,3256461,3296380,4033020,4011722,4050676,4513573,4490911,4537936
 r5n1-1kemcca-0d-sneik (100 executions),m4,2835817,2832191,2839968,2352559,2337285,2376231,2612191,2596911,2635388
@@ -177,8 +177,8 @@ Key Encapsulation Schemes,,,,,,,,,,
 Scheme,Implementation,Key Generation [bytes],Encapsulation [bytes],Decapsulation [bytes],,,,,,
 babybear,clean,6140,6092,10140,,,,,,
 babybear,opt,3104,2976,5112,,,,,,
+babybear-ephem,clean,6140,5988,4772,,,,,,
 babybear-ephem,opt,3104,3008,2440,,,,,,
-babybear-ephem,ref,6168,6088,4864,,,,,,
 firesaber,clean,22848,25600,27088,,,,,,
 firesaber,m4,20144,23008,24592,,,,,,
 frodokem640aes,m4,31992,62488,83112,,,,,,
@@ -203,8 +203,8 @@ lightsaber,clean,10576,12304,13056,,,,,,
 lightsaber,m4,9656,11392,12136,,,,,,
 mamabear,clean,6772,6716,11652,,,,,,
 mamabear,opt,3592,3464,6072,,,,,,
+mamabear-ephem,clean,6788,6612,4772,,,,,,
 mamabear-ephem,opt,3592,3488,2920,,,,,,
-mamabear-ephem,ref,6792,6712,4864,,,,,,
 newhope1024cca,clean,11120,17400,19608,,,,,,
 newhope1024cca,m4,2852,5036,5044,,,,,,
 newhope1024cpa,clean,11096,17288,8308,,,,,,
@@ -226,8 +226,8 @@ ntrulpr761,ref,14044,22492,26524,,,,,,
 ntrulpr857,ref,15692,25068,29628,,,,,,
 papabear,clean,7492,7244,13060,,,,,,
 papabear,opt,4072,3944,7032,,,,,,
+papabear-ephem,clean,7412,7340,4772,,,,,,
 papabear-ephem,opt,4072,3968,3400,,,,,,
-papabear-ephem,ref,7416,7336,4864,,,,,,
 r5n1-1kemcca-0d,m4,19676,25492,31284,,,,,,
 r5n1-1kemcca-0d,opt,19676,25492,31284,,,,,,
 r5n1-1kemcca-0d-sneik,m4,19212,25172,30964,,,,,,
@@ -351,8 +351,8 @@ Key Encapsulation Schemes,,,,,,,,,,
 Scheme,Implementation,Key Generation [%],Encapsulation [%],Decapsulation [%],,,,,,
 babybear,clean,9.7,7.3,8.6,,,,,,
 babybear,opt,55.2,47.5,41.9,,,,,,
+babybear-ephem,clean,9.7,7.7,6.5,,,,,,
 babybear-ephem,opt,55.2,48.4,35.8,,,,,,
-babybear-ephem,ref,8.4,6.5,4.3,,,,,,
 firesaber,clean,18.7,18.6,13.8,,,,,,
 firesaber,m4,49.4,49.3,40.0,,,,,,
 frodokem640aes,m4,73.6,77.1,76.3,,,,,,
@@ -377,8 +377,8 @@ lightsaber,clean,24.7,23.6,15.3,,,,,,
 lightsaber,m4,56.5,55.7,42.0,,,,,,
 mamabear,clean,8.2,6.6,7.6,,,,,,
 mamabear,opt,53.9,47.9,43.3,,,,,,
+mamabear-ephem,clean,8.2,6.8,5.7,,,,,,
 mamabear-ephem,opt,53.4,47.9,34.3,,,,,,
-mamabear-ephem,ref,7.4,6.0,3.9,,,,,,
 newhope1024cca,clean,59.5,59.1,47.6,,,,,,
 newhope1024cca,m4,74.4,78.5,70.3,,,,,,
 newhope1024cpa,clean,53.9,50.2,4.3,,,,,,
@@ -400,8 +400,8 @@ ntrulpr761,ref,0.4,0.4,0.2,,,,,,
 ntrulpr857,ref,0.3,0.4,0.2,,,,,,
 papabear,clean,7.5,6.3,7.1,,,,,,
 papabear,opt,52.7,47.9,44.0,,,,,,
+papabear-ephem,clean,7.5,6.4,5.3,,,,,,
 papabear-ephem,opt,52.3,47.9,33.2,,,,,,
-papabear-ephem,ref,6.9,5.8,3.6,,,,,,
 r5n1-1kemcca-0d,m4,24.1,51.1,51.3,,,,,,
 r5n1-1kemcca-0d,opt,25.1,42.2,43.4,,,,,,
 r5n1-1kemcca-0d-sneik,m4,0.0,0.0,0.0,,,,,,
@@ -525,8 +525,8 @@ Key Encapsulation Schemes,,,,,,,,,,
 Scheme,Implementation,.text [bytes],.data [bytes],.bss [bytes],Total [bytes],,,,,
 babybear,clean,5079,0,0,5079,,,,,
 babybear,opt,5627,0,0,5627,,,,,
+babybear-ephem,clean,4875,0,0,4875,,,,,
 babybear-ephem,opt,4985,0,0,4985,,,,,
-babybear-ephem,ref,4892,0,0,4892,,,,,
 firesaber,clean,11208,0,0,11208,,,,,
 firesaber,m4,44184,0,0,44184,,,,,
 frodokem640aes,m4,8496,0,0,8496,,,,,
@@ -551,8 +551,8 @@ lightsaber,clean,11936,0,0,11936,,,,,
 lightsaber,m4,44916,0,0,44916,,,,,
 mamabear,clean,5571,0,0,5571,,,,,
 mamabear,opt,5623,0,0,5623,,,,,
+mamabear-ephem,clean,4887,0,0,4887,,,,,
 mamabear-ephem,opt,4917,0,0,4917,,,,,
-mamabear-ephem,ref,4900,0,0,4900,,,,,
 newhope1024cca,clean,10780,0,0,10780,,,,,
 newhope1024cca,m4,12092,4096,0,16188,,,,,
 newhope1024cpa,clean,10384,0,0,10384,,,,,
@@ -574,8 +574,8 @@ ntrulpr761,ref,4632,0,0,4632,,,,,
 ntrulpr857,ref,4696,0,0,4696,,,,,
 papabear,clean,5559,0,0,5559,,,,,
 papabear,opt,5559,0,0,5559,,,,,
+papabear-ephem,clean,4915,0,0,4915,,,,,
 papabear-ephem,opt,4877,0,0,4877,,,,,
-papabear-ephem,ref,4908,0,0,4908,,,,,
 r5n1-1kemcca-0d,m4,3089,0,0,3089,,,,,
 r5n1-1kemcca-0d,opt,4195,0,0,4195,,,,,
 r5n1-1kemcca-0d-sneik,m4,4584,0,0,4584,,,,,

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -4,8 +4,8 @@
 | ------ | -------------- | ----------------------- | ---------------------- | ---------------------- |
 | babybear (100 executions) | clean | AVG: 4,031,805 <br /> MIN: 4,031,805 <br /> MAX: 4,031,805 | AVG: 5,878,092 <br /> MIN: 5,878,092 <br /> MAX: 5,878,092 | AVG: 11,997,012 <br /> MIN: 11,997,012 <br /> MAX: 11,997,012 |
 | babybear (100 executions) | opt | AVG: 596,665 <br /> MIN: 596,665 <br /> MAX: 596,665 | AVG: 752,117 <br /> MIN: 752,117 <br /> MAX: 752,117 | AVG: 1,142,773 <br /> MIN: 1,142,773 <br /> MAX: 1,142,773 |
+| babybear-ephem (100 executions) | clean | AVG: 4,031,806 <br /> MIN: 4,031,806 <br /> MAX: 4,031,806 | AVG: 5,905,062 <br /> MIN: 5,905,062 <br /> MAX: 5,905,062 | AVG: 1,998,296 <br /> MIN: 1,998,296 <br /> MAX: 1,998,296 |
 | babybear-ephem (100 executions) | opt | AVG: 596,664 <br /> MIN: 596,664 <br /> MAX: 596,664 | AVG: 767,860 <br /> MIN: 767,860 <br /> MAX: 767,860 | AVG: 231,728 <br /> MIN: 231,728 <br /> MAX: 231,728 |
-| babybear-ephem (100 executions) | ref | AVG: 3,968,935 <br /> MIN: 3,968,935 <br /> MAX: 3,968,935 | AVG: 5,817,861 <br /> MIN: 5,817,861 <br /> MAX: 5,817,861 | AVG: 1,948,755 <br /> MIN: 1,948,755 <br /> MAX: 1,948,755 |
 | firesaber (100 executions) | clean | AVG: 3,816,702 <br /> MIN: 3,816,702 <br /> MAX: 3,816,702 | AVG: 4,743,325 <br /> MIN: 4,743,325 <br /> MAX: 4,743,325 | AVG: 5,355,474 <br /> MIN: 5,355,474 <br /> MAX: 5,355,474 |
 | firesaber (100 executions) | m4 | AVG: 1,448,776 <br /> MIN: 1,448,776 <br /> MAX: 1,448,776 | AVG: 1,786,930 <br /> MIN: 1,786,930 <br /> MAX: 1,786,930 | AVG: 1,853,339 <br /> MIN: 1,853,339 <br /> MAX: 1,853,339 |
 | frodokem640aes (100 executions) | m4 | AVG: 47,050,559 <br /> MIN: 47,050,559 <br /> MAX: 47,050,559 | AVG: 45,883,334 <br /> MIN: 45,883,334 <br /> MAX: 45,883,334 | AVG: 45,366,065 <br /> MIN: 45,366,065 <br /> MAX: 45,366,065 |
@@ -30,8 +30,8 @@
 | lightsaber (100 executions) | m4 | AVG: 459,965 <br /> MIN: 459,965 <br /> MAX: 459,965 | AVG: 651,273 <br /> MIN: 651,273 <br /> MAX: 651,273 | AVG: 678,810 <br /> MIN: 678,810 <br /> MAX: 678,810 |
 | mamabear (100 executions) | clean | AVG: 8,861,427 <br /> MIN: 8,861,427 <br /> MAX: 8,861,427 | AVG: 11,598,380 <br /> MIN: 11,598,380 <br /> MAX: 11,598,380 | AVG: 23,520,327 <br /> MIN: 23,520,327 <br /> MAX: 23,520,327 |
 | mamabear (100 executions) | opt | AVG: 1,195,048 <br /> MIN: 1,195,048 <br /> MAX: 1,195,048 | AVG: 1,402,955 <br /> MIN: 1,402,955 <br /> MAX: 1,402,955 | AVG: 1,955,496 <br /> MIN: 1,955,496 <br /> MAX: 1,955,496 |
+| mamabear-ephem (100 executions) | clean | AVG: 8,870,888 <br /> MIN: 8,870,888 <br /> MAX: 8,870,888 | AVG: 11,637,666 <br /> MIN: 11,637,666 <br /> MAX: 11,637,666 | AVG: 2,938,885 <br /> MIN: 2,938,885 <br /> MAX: 2,938,885 |
 | mamabear-ephem (100 executions) | opt | AVG: 1,206,350 <br /> MIN: 1,206,350 <br /> MAX: 1,206,350 | AVG: 1,431,341 <br /> MIN: 1,431,341 <br /> MAX: 1,431,341 | AVG: 320,233 <br /> MIN: 320,233 <br /> MAX: 320,233 |
-| mamabear-ephem (100 executions) | ref | AVG: 8,783,565 <br /> MIN: 8,783,565 <br /> MAX: 8,783,565 | AVG: 11,525,870 <br /> MIN: 11,525,870 <br /> MAX: 11,525,870 | AVG: 2,876,105 <br /> MIN: 2,876,105 <br /> MAX: 2,876,105 |
 | newhope1024cca (100 executions) | clean | AVG: 1,460,167 <br /> MIN: 1,459,836 <br /> MAX: 1,460,406 | AVG: 2,264,773 <br /> MIN: 2,264,441 <br /> MAX: 2,265,011 | AVG: 2,410,906 <br /> MIN: 2,410,574 <br /> MAX: 2,411,144 |
 | newhope1024cca (100 executions) | m4 | AVG: 1,157,677 <br /> MIN: 1,157,321 <br /> MAX: 1,158,018 | AVG: 1,688,875 <br /> MIN: 1,688,519 <br /> MAX: 1,689,216 | AVG: 1,614,268 <br /> MIN: 1,613,912 <br /> MAX: 1,614,609 |
 | newhope1024cpa (100 executions) | clean | AVG: 1,274,813 <br /> MIN: 1,274,572 <br /> MAX: 1,275,142 | AVG: 1,857,055 <br /> MIN: 1,856,813 <br /> MAX: 1,857,383 | AVG: 327,778 <br /> MIN: 327,778 <br /> MAX: 327,778 |
@@ -53,8 +53,8 @@
 | ntrulpr857 (100 executions) | ref | AVG: 94,016,969 <br /> MIN: 94,016,969 <br /> MAX: 94,016,969 | AVG: 187,235,730 <br /> MIN: 187,235,730 <br /> MAX: 187,235,730 | AVG: 280,075,965 <br /> MIN: 280,075,965 <br /> MAX: 280,075,965 |
 | papabear (100 executions) | clean | AVG: 15,587,475 <br /> MIN: 15,587,475 <br /> MAX: 15,587,475 | AVG: 19,220,187 <br /> MIN: 19,220,187 <br /> MAX: 19,220,187 | AVG: 38,837,350 <br /> MIN: 38,837,350 <br /> MAX: 38,837,350 |
 | papabear (100 executions) | opt | AVG: 2,014,216 <br /> MIN: 2,014,216 <br /> MAX: 2,014,216 | AVG: 2,276,138 <br /> MIN: 2,276,138 <br /> MAX: 2,276,138 | AVG: 3,000,239 <br /> MIN: 3,000,239 <br /> MAX: 3,000,239 |
+| papabear-ephem (100 executions) | clean | AVG: 15,601,295 <br /> MIN: 15,601,295 <br /> MAX: 15,601,295 | AVG: 19,261,570 <br /> MIN: 19,261,570 <br /> MAX: 19,261,570 | AVG: 3,879,464 <br /> MIN: 3,879,464 <br /> MAX: 3,879,464 |
 | papabear-ephem (100 executions) | opt | AVG: 2,029,284 <br /> MIN: 2,029,284 <br /> MAX: 2,029,284 | AVG: 2,308,148 <br /> MIN: 2,308,148 <br /> MAX: 2,308,148 | AVG: 411,623 <br /> MIN: 411,623 <br /> MAX: 411,623 |
-| papabear-ephem (100 executions) | ref | AVG: 15,490,269 <br /> MIN: 15,490,269 <br /> MAX: 15,490,269 | AVG: 19,126,020 <br /> MIN: 19,126,020 <br /> MAX: 19,126,020 | AVG: 3,803,444 <br /> MIN: 3,803,444 <br /> MAX: 3,803,444 |
 | r5n1-1kemcca-0d (100 executions) | m4 | AVG: 3,468,700 <br /> MIN: 3,452,036 <br /> MAX: 3,487,229 | AVG: 3,311,885 <br /> MIN: 3,287,627 <br /> MAX: 3,335,808 | AVG: 3,791,981 <br /> MIN: 3,762,550 <br /> MAX: 3,826,612 |
 | r5n1-1kemcca-0d (100 executions) | opt | AVG: 3,275,672 <br /> MIN: 3,256,461 <br /> MAX: 3,296,380 | AVG: 4,033,020 <br /> MIN: 4,011,722 <br /> MAX: 4,050,676 | AVG: 4,513,573 <br /> MIN: 4,490,911 <br /> MAX: 4,537,936 |
 | r5n1-1kemcca-0d-sneik (100 executions) | m4 | AVG: 2,835,817 <br /> MIN: 2,832,191 <br /> MAX: 2,839,968 | AVG: 2,352,559 <br /> MIN: 2,337,285 <br /> MAX: 2,376,231 | AVG: 2,612,191 <br /> MIN: 2,596,911 <br /> MAX: 2,635,388 |
@@ -180,8 +180,8 @@
 | ------ | -------------- | ---------------------- | --------------------- | --------------------- |
 | babybear | clean | 6,140 | 6,092 | 10,140 |
 | babybear | opt | 3,104 | 2,976 | 5,112 |
+| babybear-ephem | clean | 6,140 | 5,988 | 4,772 |
 | babybear-ephem | opt | 3,104 | 3,008 | 2,440 |
-| babybear-ephem | ref | 6,168 | 6,088 | 4,864 |
 | firesaber | clean | 22,848 | 25,600 | 27,088 |
 | firesaber | m4 | 20,144 | 23,008 | 24,592 |
 | frodokem640aes | m4 | 31,992 | 62,488 | 83,112 |
@@ -206,8 +206,8 @@
 | lightsaber | m4 | 9,656 | 11,392 | 12,136 |
 | mamabear | clean | 6,772 | 6,716 | 11,652 |
 | mamabear | opt | 3,592 | 3,464 | 6,072 |
+| mamabear-ephem | clean | 6,788 | 6,612 | 4,772 |
 | mamabear-ephem | opt | 3,592 | 3,488 | 2,920 |
-| mamabear-ephem | ref | 6,792 | 6,712 | 4,864 |
 | newhope1024cca | clean | 11,120 | 17,400 | 19,608 |
 | newhope1024cca | m4 | 2,852 | 5,036 | 5,044 |
 | newhope1024cpa | clean | 11,096 | 17,288 | 8,308 |
@@ -229,8 +229,8 @@
 | ntrulpr857 | ref | 15,692 | 25,068 | 29,628 |
 | papabear | clean | 7,492 | 7,244 | 13,060 |
 | papabear | opt | 4,072 | 3,944 | 7,032 |
+| papabear-ephem | clean | 7,412 | 7,340 | 4,772 |
 | papabear-ephem | opt | 4,072 | 3,968 | 3,400 |
-| papabear-ephem | ref | 7,416 | 7,336 | 4,864 |
 | r5n1-1kemcca-0d | m4 | 19,676 | 25,492 | 31,284 |
 | r5n1-1kemcca-0d | opt | 19,676 | 25,492 | 31,284 |
 | r5n1-1kemcca-0d-sneik | m4 | 19,212 | 25,172 | 30,964 |
@@ -356,8 +356,8 @@
 | ------ | -------------- | ------------------ | ----------------- | ----------------- |
 | babybear | clean | 9.7% | 7.3% | 8.6% |
 | babybear | opt | 55.2% | 47.5% | 41.9% |
+| babybear-ephem | clean | 9.7% | 7.7% | 6.5% |
 | babybear-ephem | opt | 55.2% | 48.4% | 35.8% |
-| babybear-ephem | ref | 8.4% | 6.5% | 4.3% |
 | firesaber | clean | 18.7% | 18.6% | 13.8% |
 | firesaber | m4 | 49.4% | 49.3% | 40.0% |
 | frodokem640aes | m4 | 73.6% | 77.1% | 76.3% |
@@ -380,8 +380,8 @@
 | lac256 | ref | 3.4% | 2.5% | 1.6% |
 | mamabear | clean | 8.2% | 6.6% | 7.6% |
 | mamabear | opt | 53.9% | 47.9% | 43.3% |
+| mamabear-ephem | clean | 8.2% | 6.8% | 5.7% |
 | mamabear-ephem | opt | 53.4% | 47.9% | 34.3% |
-| mamabear-ephem | ref | 7.4% | 6.0% | 3.9% |
 | lightsaber | clean | 24.7% | 23.6% | 15.3% |
 | lightsaber | m4 | 56.5% | 55.7% | 42.0% |
 | newhope1024cca | clean | 59.5% | 59.1% | 47.6% |
@@ -405,8 +405,8 @@
 | ntrulpr857 | ref | 0.3% | 0.4% | 0.2% |
 | papabear | clean | 7.5% | 6.3% | 7.1% |
 | papabear | opt | 52.7% | 47.9% | 44.0% |
+| papabear-ephem | clean | 7.5% | 6.4% | 5.3% |
 | papabear-ephem | opt | 52.3% | 47.9% | 33.2% |
-| papabear-ephem | ref | 6.9% | 5.8% | 3.6% |
 | r5n1-1kemcca-0d | m4 | 24.1% | 51.1% | 51.3% |
 | r5n1-1kemcca-0d | opt | 25.1% | 42.2% | 43.4% |
 | r5n1-1kemcca-0d-sneik | m4 | 0.0% | 0.0% | 0.0% |
@@ -532,8 +532,8 @@
 | ------ | -------------- | ------------- | ------------- | ------------ | ------------- |
 | babybear | clean | 5,079 | 0 | 0 | 5,079 |
 | babybear | opt | 5,627 | 0 | 0 | 5,627 |
+| babybear-ephem | clean | 4,875 | 0 | 0 | 4,875 |
 | babybear-ephem | opt | 4,985 | 0 | 0 | 4,985 |
-| babybear-ephem | ref | 4,892 | 0 | 0 | 4,892 |
 | firesaber | clean | 11,208 | 0 | 0 | 11,208 |
 | firesaber | m4 | 44,184 | 0 | 0 | 44,184 |
 | frodokem640aes | m4 | 8,496 | 0 | 0 | 8,496 |
@@ -558,8 +558,8 @@
 | lightsaber | m4 | 44,916 | 0 | 0 | 44,916 |
 | mamabear | clean | 5,571 | 0 | 0 | 5,571 |
 | mamabear | opt | 5,623 | 0 | 0 | 5,623 |
+| mamabear-ephem | clean | 4,887 | 0 | 0 | 4,887 |
 | mamabear-ephem | opt | 4,917 | 0 | 0 | 4,917 |
-| mamabear-ephem | ref | 4,900 | 0 | 0 | 4,900 |
 | newhope1024cca | clean | 10,780 | 0 | 0 | 10,780 |
 | newhope1024cca | m4 | 12,092 | 4,096 | 0 | 16,188 |
 | newhope1024cpa | clean | 10,384 | 0 | 0 | 10,384 |
@@ -581,8 +581,8 @@
 | ntrulpr857 | ref | 4,696 | 0 | 0 | 4,696 |
 | papabear | clean | 5,559 | 0 | 0 | 5,559 |
 | papabear | opt | 5,559 | 0 | 0 | 5,559 |
+| papabear-ephem | clean | 4,915 | 0 | 0 | 4,915 |
 | papabear-ephem | opt | 4,877 | 0 | 0 | 4,877 |
-| papabear-ephem | ref | 4,908 | 0 | 0 | 4,908 |
 | r5n1-1kemcca-0d | m4 | 3,089 | 0 | 0 | 3,089 |
 | r5n1-1kemcca-0d | opt | 4,195 | 0 | 0 | 4,195 |
 | r5n1-1kemcca-0d-sneik | m4 | 4,584 | 0 | 0 | 4,584 |


### PR DESCRIPTION
The ephemeral three bears got integrated into PQClean recently https://github.com/PQClean/PQClean/pull/262, and I've updated the benchmarks. 
They seem to be negligibly slower. 

This also includes some minor fixes in mupq: https://github.com/mupq/mupq/pull/39, https://github.com/mupq/mupq/pull/40, https://github.com/mupq/mupq/pull/41, https://github.com/mupq/mupq/pull/42.