### PR TITLE
Remove unused NewHope verify function

### DIFF
--- a/crypto_kem/newhope1024cca/m4/verify.c
+++ b/crypto_kem/newhope1024cca/m4/verify.c
@@ -3,30 +3,6 @@
 #include <string.h>
 
 /*************************************************
-* Name:        verify
-*
-* Description: Compare two arrays for equality in constant time.
-*
-* Arguments:   const unsigned char *a: pointer to first byte array
-*              const unsigned char *b: pointer to second byte array
-*              size_t len:             length of the byte arrays
-*
-* Returns 0 if the byte arrays are equal, 1 otherwise
-**************************************************/
-int verify(const unsigned char *a, const unsigned char *b, size_t len) {
-  uint64_t r;
-  size_t i;
-  r = 0;
-
-  for (i = 0; i < len; i++) {
-    r |= a[i] ^ b[i];
-  }
-
-  r = (-(int64_t)r) >> 63;
-  return (int)r;
-}
-
-/*************************************************
 * Name:        cmov
 *
 * Description: Copy len bytes from x to r if b is 1;

--- a/crypto_kem/newhope1024cca/m4/verify.h
+++ b/crypto_kem/newhope1024cca/m4/verify.h
@@ -3,9 +3,6 @@
 
 #include <stdio.h>
 
-/* returns 0 for equal strings, 1 for non-equal strings */
-int verify(const unsigned char *a, const unsigned char *b, size_t len);
-
 /* b = 1 means mov, b = 0 means don't mov*/
 void cmov(unsigned char *r, const unsigned char *x, size_t len, unsigned char b);
 

--- a/crypto_kem/newhope1024cpa/m4/verify.c
+++ b/crypto_kem/newhope1024cpa/m4/verify.c
@@ -3,30 +3,6 @@
 #include <string.h>
 
 /*************************************************
-* Name:        verify
-*
-* Description: Compare two arrays for equality in constant time.
-*
-* Arguments:   const unsigned char *a: pointer to first byte array
-*              const unsigned char *b: pointer to second byte array
-*              size_t len:             length of the byte arrays
-*
-* Returns 0 if the byte arrays are equal, 1 otherwise
-**************************************************/
-int verify(const unsigned char *a, const unsigned char *b, size_t len) {
-  uint64_t r;
-  size_t i;
-  r = 0;
-
-  for (i = 0; i < len; i++) {
-    r |= a[i] ^ b[i];
-  }
-
-  r = (-(int64_t)r) >> 63;
-  return (int)r;
-}
-
-/*************************************************
 * Name:        cmov
 *
 * Description: Copy len bytes from x to r if b is 1;

--- a/crypto_kem/newhope1024cpa/m4/verify.h
+++ b/crypto_kem/newhope1024cpa/m4/verify.h
@@ -3,9 +3,6 @@
 
 #include <stdio.h>
 
-/* returns 0 for equal strings, 1 for non-equal strings */
-int verify(const unsigned char *a, const unsigned char *b, size_t len);
-
 /* b = 1 means mov, b = 0 means don't mov*/
 void cmov(unsigned char *r, const unsigned char *x, size_t len, unsigned char b);
 

--- a/crypto_kem/newhope512cca/m4/verify.c
+++ b/crypto_kem/newhope512cca/m4/verify.c
@@ -3,30 +3,6 @@
 #include <string.h>
 
 /*************************************************
-* Name:        verify
-*
-* Description: Compare two arrays for equality in constant time.
-*
-* Arguments:   const unsigned char *a: pointer to first byte array
-*              const unsigned char *b: pointer to second byte array
-*              size_t len:             length of the byte arrays
-*
-* Returns 0 if the byte arrays are equal, 1 otherwise
-**************************************************/
-int verify(const unsigned char *a, const unsigned char *b, size_t len) {
-  uint64_t r;
-  size_t i;
-  r = 0;
-
-  for (i = 0; i < len; i++) {
-    r |= a[i] ^ b[i];
-  }
-
-  r = (-(int64_t)r) >> 63;
-  return (int)r;
-}
-
-/*************************************************
 * Name:        cmov
 *
 * Description: Copy len bytes from x to r if b is 1;

--- a/crypto_kem/newhope512cca/m4/verify.h
+++ b/crypto_kem/newhope512cca/m4/verify.h
@@ -3,9 +3,6 @@
 
 #include <stdio.h>
 
-/* returns 0 for equal strings, 1 for non-equal strings */
-int verify(const unsigned char *a, const unsigned char *b, size_t len);
-
 /* b = 1 means mov, b = 0 means don't mov*/
 void cmov(unsigned char *r, const unsigned char *x, size_t len, unsigned char b);
 

--- a/crypto_kem/newhope512cpa/m4/verify.c
+++ b/crypto_kem/newhope512cpa/m4/verify.c
@@ -3,30 +3,6 @@
 #include <string.h>
 
 /*************************************************
-* Name:        verify
-*
-* Description: Compare two arrays for equality in constant time.
-*
-* Arguments:   const unsigned char *a: pointer to first byte array
-*              const unsigned char *b: pointer to second byte array
-*              size_t len:             length of the byte arrays
-*
-* Returns 0 if the byte arrays are equal, 1 otherwise
-**************************************************/
-int verify(const unsigned char *a, const unsigned char *b, size_t len) {
-  uint64_t r;
-  size_t i;
-  r = 0;
-
-  for (i = 0; i < len; i++) {
-    r |= a[i] ^ b[i];
-  }
-
-  r = (-(int64_t)r) >> 63;
-  return (int)r;
-}
-
-/*************************************************
 * Name:        cmov
 *
 * Description: Copy len bytes from x to r if b is 1;

--- a/crypto_kem/newhope512cpa/m4/verify.h
+++ b/crypto_kem/newhope512cpa/m4/verify.h
@@ -3,9 +3,6 @@
 
 #include <stdio.h>
 
-/* returns 0 for equal strings, 1 for non-equal strings */
-int verify(const unsigned char *a, const unsigned char *b, size_t len);
-
 /* b = 1 means mov, b = 0 means don't mov*/
 void cmov(unsigned char *r, const unsigned char *x, size_t len, unsigned char b);
 


### PR DESCRIPTION
#132 reported that the verify function is not actually doing what it is supposed to do.
As it is not used in the current pqm4 implementation of NewHope, I remove it here. 
For more details see #132.

The function needs to be fixed in PQClean: https://github.com/PQClean/PQClean/issues/269