### PR TITLE
Fix ntruprime implementations for old gcc versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OBJCOPY     = $(PREFIX)-objcopy
 ARCH_FLAGS  = -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 DEFINES     = -DSTM32F4
 
-CFLAGS     += -O3 \
+CFLAGS     += -O3 -std=gnu99 \
               -Wall -Wextra -Wimplicit-function-declaration \
               -Wredundant-decls -Wmissing-prototypes -Wstrict-prototypes \
               -Wundef -Wshadow \

--- a/crypto_kem/ntrulpr761/m4f/Short_fromlist_asm_ntrulpr761.S
+++ b/crypto_kem/ntrulpr761/m4f/Short_fromlist_asm_ntrulpr761.S
@@ -120,7 +120,7 @@ Short_fromlist_asm_zero:
   str.w r2, [r0], #4
 
   mov.w r0, sp
-  mov.w r2, #761
+  movw.w r2, #761
   mov.w r3, #0
   vmov.w r4, s0
   bl.w uint32_sort
@@ -155,7 +155,7 @@ Short_fromlist_asm_back:
   str.w r2, [r4], #8
   cmp.w r0, lr
   bne.w Short_fromlist_asm_back
-    
+
   ldr.w r5, [r0]
   and.w r5, #3
   sub.w r5, #1

--- a/crypto_kem/sntrup761/m4f/Decode_asm.S
+++ b/crypto_kem/sntrup761/m4f/Decode_asm.S
@@ -14,8 +14,8 @@ Decode_Rq_asm:
   add.w r2, r0, #92
   movw.w r4, #0xFEF0
   movt.w r4, #644
-  mov.w r5, #0x9A3C
-  mov.w r11, #0xE361
+  movw.w r5, #0x9A3C
+  movw.w r11, #0xE361
   movw.w r12, #0xFD7C
   movt.w r12, #0xFFFF
   movw.w r3, #0xEE11
@@ -73,8 +73,8 @@ Decode_Rq_asm_radix644:
   add.w r2, r0, #186
   movw.w r4, #78
   movt.w r4, #406
-  mov.w r5, #24213
-  mov.w r11, #25827
+  movw.w r5, #24213
+  movw.w r11, #25827
   movw.w r12, #0xFE6A
   movt.w r12, #0xFFFF
 
@@ -152,8 +152,8 @@ Decode_Rq_asm_radix406:
   add.w r2, r0, #376
   movw.w r4, #50
   movt.w r4, #322
-  mov.w r5, #13433
-  mov.w r11, #0xE361
+  movw.w r5, #13433
+  movw.w r11, #0xE361
   movw.w r12, #0xFEBE
   movt.w r12, #0xFFFF
 
@@ -214,8 +214,8 @@ Decode_Rq_asm_radix322:
   movt.w r3, #2295
   movw.w r4, #1702
   movt.w r4, #4591
-  mov.w r5, #0xF1BA
-  mov.w r11, #15631
+  movw.w r5, #0xF1BA
+  movw.w r11, #15631
   movw.w r12, #0xEE11
   movt.w r12, #0xFFFF
 
@@ -285,8 +285,8 @@ Decode_Rounded_asm:
   add.w r2, r0, #8
   movw.w r4, #2348
   movt.w r4, #9097
-  mov.w r5, #0xF8CC
-  mov.w r11, #17081
+  movw.w r5, #0xF8CC
+  movw.w r11, #17081
   movw.w r12, #0xDC77
   movt.w r12, #0xFFFF
   movw.w r3, #0xF774
@@ -350,8 +350,8 @@ Decode_Rounded_asm_radix9097:
   add.w r2, r0, #20
   movw.w r4, #372
   movt.w r4, #1526
-  mov.w r5, #0xD50E
-  mov.w r11, #0xB833
+  movw.w r5, #0xD50E
+  movw.w r11, #0xB833
   movw.w r12, #0xFA0A
   movt.w r12, #0xFFFF
   movw.w r3, #0xFE91
@@ -406,8 +406,8 @@ Decode_Rounded_asm_radix1526:
   add.w r2, r0, #44
   movw.w r4, #0xFEE4
   movt.w r4, #625
-  mov.w r5, #0x9724
-  mov.w r11, #32401
+  movw.w r5, #0x9724
+  movw.w r11, #32401
   movw.w r12, #0xFD8F
   movt.w r12, #0xFFFF
   movw.w r3, #0xFF6A
@@ -461,8 +461,8 @@ Decode_Rounded_asm_radix625:
   add.w r2, r0, #92
   movw.w r4, #2816
   movt.w r4, #6400
-  mov.w r5, #0xF5C3
-  mov.w r11, #23593
+  movw.w r5, #0xF5C3
+  movw.w r11, #23593
   movw.w r12, #0xE700
   movt.w r12, #0xFFFF
   movw.w r3, #0xFA05
@@ -535,7 +535,7 @@ Decode_Rounded_asm_radix6400:
   add.w r2, r0, #186
   movw.w r4, #256
   movt.w r4, #1280
-  mov.w r5, #0xCCCD
+  movw.w r5, #0xCCCD
   movw.w r12, #0xFB00
   movt.w r12, #0xFFFF
 
@@ -608,8 +608,8 @@ Decode_Rounded_asm_radix1280:
   add.w r2, r0, #376
   movw.w r4, #1592
   movt.w r4, #9157
-  mov.w r5, #0xF8D8
-  mov.w r11, #25357
+  movw.w r5, #0xF8D8
+  movw.w r11, #25357
   movw.w r12, #0xDC3B
   movt.w r12, #0xFFFF
 
@@ -675,8 +675,8 @@ Decode_Rounded_asm_radix9157:
   movt.w r3, #2295
   movw.w r4, #518
   movt.w r4, #1531
-  mov.w r5, #0xD532
-  mov.w r11, #15667
+  movw.w r5, #0xD532
+  movw.w r11, #15667
   movw.w r12, #0xFA05
   movt.w r12, #0xFFFF
 

--- a/crypto_kem/sntrup761/m4f/Encode_asm.S
+++ b/crypto_kem/sntrup761/m4f/Encode_asm.S
@@ -10,7 +10,7 @@ Encode_Rq_asm:
 
   add.w lr, r1, #1520
   mov.w r2, r1
-  mov.w r3, #4591
+  movw.w r3, #4591
   movw.w r4, #2295
   movt.w r4, #2295
 Encode_Rq_asm_radix4591:
@@ -151,7 +151,7 @@ Encode_Rounded_asm:
 
   add.w lr, r1, #1520
   mov.w r2, r1
-  mov.w r3, #1531
+  movw.w r3, #1531
   movw.w r4, #2295
   movt.w r4, #2295
   mov.w r5, #0x55555555
@@ -203,7 +203,7 @@ Encode_Rounded_asm_radix1531:
   sub.w r2, #760
 
   add.w lr, r1, #752
-  mov.w r3, #9157
+  movw.w r3, #9157
 Encode_Rounded_asm_radix9157:
   ldr.w r5, [r1, #4]
   ldr.w r6, [r1, #8]

--- a/crypto_kem/sntrup761/m4f/Rq_mult3_asm.S
+++ b/crypto_kem/sntrup761/m4f/Rq_mult3_asm.S
@@ -28,7 +28,7 @@ Rq_mult3_asm:
 
   movw loopctr, #95
   movw three, #3
-  mov mq, #4591
+  movw mq, #4591
   neg mq, mq
   movw barrettconst, #0x465f
   movt barrettconst, #0xe

--- a/crypto_kem/sntrup761/m4f/Rq_redp.S
+++ b/crypto_kem/sntrup761/m4f/Rq_redp.S
@@ -26,9 +26,9 @@ Rq_redp:
   mq            .req r11
   barrettconst  .req r12
 
-  mov loopctr, #379
+  movw loopctr, #379
   mov twop15, #32768
-  mov mq, #4591
+  movw mq, #4591
   neg mq, mq
   movw barrettconst, #0x465f
   movt barrettconst, #0xe

--- a/crypto_kem/sntrup761/m4f/Short_fromlist_asm_sntrup761.S
+++ b/crypto_kem/sntrup761/m4f/Short_fromlist_asm_sntrup761.S
@@ -107,7 +107,7 @@ Short_fromlist_asm_zero:
   str.w r2, [r0], #20
 
   mov.w r0, sp
-  mov.w r2, #761
+  movw.w r2, #761
   mov.w r3, #0
   vmov.w r4, s0
   bl.w uint32_sort

--- a/crypto_kem/sntrup761/m4f/jump4divsteps.S
+++ b/crypto_kem/sntrup761/m4f/jump4divsteps.S
@@ -1,5 +1,5 @@
 #include "red-asm.h"
-	.p2align	2,,3	
+	.p2align	2,,3
 	.syntax		unified
 	.text
 M2x2x2s:
@@ -27,7 +27,7 @@ M2x2x2s:
 	str	r10, [r0, #20]
 	str	r2, [r0, #16]
 	pop	{pc}
-	.p2align	2,,3	
+	.p2align	2,,3
 	.syntax		unified
 	.text
 M2x2x2_2:
@@ -60,7 +60,7 @@ M2x2x2_2:
 	str	r2, [r0]
 	str	r10, [r0, #4]
 	pop	{pc}
-	.p2align	2,,3	
+	.p2align	2,,3
 	.syntax		unified
 	.text
 jump2divsteps_sub:
@@ -89,7 +89,7 @@ jump2divsteps_t0_1:	// end of first half
 	mov	r11, #0
 	ssub16	r8, r11, r3	// r8 = -g
 	sub	r0, r0, #1	// decrement minusdelta
-	smlsdx	r3, r2, r3, r11	// (f(0) g - g(0) f) / x 
+	smlsdx	r3, r2, r3, r11	// (f(0) g - g(0) f) / x
 	br_32	r3, r12, r1, r11 //red. new g[0] % 4591, 32b
 	uxth	r3, r3
 	smulbb	r9, r8, r4	// - u[0] g[0]
@@ -121,7 +121,7 @@ jump2divsteps_t1_1:	// end of first half
 	mov	r11, #0
 	sub	r0, r0, #1	// decrement minusdelta
 	ssub16	r8, r11, r3	// r8 = -g
-	smlsdx	r3, r2, r3, r11	// (f(0) g - g(0) f) / x 
+	smlsdx	r3, r2, r3, r11	// (f(0) g - g(0) f) / x
 	br_32	r3, r12, r1, r11 //red. new g[0] % 4591, 32b
 	uxth	r3, r3
 	smulbb	r9, r8, r4	// - u[0] g[0]
@@ -138,7 +138,7 @@ jump2divsteps_t1_1:	// end of first half
 	pkhbt	r7, r9, r11, LSL #16	// new s (new s[1] reduced)
 	// note, we don't shift u,v here
 	pop	{pc}
-	.p2align	2,,3	
+	.p2align	2,,3
 	.syntax		unified
 	.text
 // void jump4divsteps (int minusdelta, int *M, int *f, int *g);
@@ -146,7 +146,7 @@ jump2divsteps_t1_1:	// end of first half
 	.type	jump4divsteps, %function
 jump4divsteps:
 	push	{r1-r11,lr}
-	mov	r12, #4591	// load q
+	movw	r12, #4591	// load q
 	movw	r1, #47521
 	movt	r1, #65521
 	vmov	s0, r1		// save q32inv
@@ -185,7 +185,7 @@ jump4divsteps:
 	add	sp, sp, #76	// deallocate temp storage + pop r1-3
 	vmov	r0, s1		// reload minusdelta for return value
 	pop	{r4-r11,pc}
-	.p2align	2,,3	
+	.p2align	2,,3
 	.syntax		unified
 	.text
 jump2divsteps_1_sub:
@@ -214,7 +214,7 @@ jump2divsteps_1_t0_1:	// end of first half
 	mov	r11, #0
 	ssub16	r8, r11, r3	// r8 = -g
 	sub	r0, r0, #1	// decrement minusdelta
-	smlsdx	r3, r2, r3, r11	// (f(0) g - g(0) f) / x 
+	smlsdx	r3, r2, r3, r11	// (f(0) g - g(0) f) / x
 	br_32	r3, r12, r1, r11 //red. new g[0] % 4591, 32b
 	uxth	r3, r3
 	smulbb	r9, r8, r4	// - u[0] g[0]
@@ -232,7 +232,7 @@ jump2divsteps_1_t0_1:	// end of first half
  // note M redefined here
  // note pf redefined here
  // note pg redefined here
-	.p2align	2,,3	
+	.p2align	2,,3
 	.syntax		unified
 	.text
 // void jump4divsteps_3 (int minusdelta, int *M, int *f, int *g);
@@ -240,7 +240,7 @@ jump2divsteps_1_t0_1:	// end of first half
 	.type	jump4divsteps_3, %function
 jump4divsteps_3:
 	push	{r1-r11,lr}
-	mov	r12, #4591	// load q
+	movw	r12, #4591	// load q
 	movw	r1, #47521
 	movt	r1, #65521
 	vmov	s0, r1		// save q32inv
@@ -279,7 +279,7 @@ jump4divsteps_3:
 	add	sp, sp, #76	// deallocate temp storage + pop r1-3
 	vmov	r0, s1		// reload minusdelta for return value
 	pop	{r4-r11,pc}
-	.p2align	2,,3	
+	.p2align	2,,3
 	.syntax		unified
 	.text
 // void jump4divsteps_2 (int minusdelta, int *M, int *f, int *g);
@@ -287,7 +287,7 @@ jump4divsteps_3:
 	.type	jump4divsteps_2, %function
 jump4divsteps_2:
 	push	{r1-r11,lr}
-	mov	r12, #4591	// load q
+	movw	r12, #4591	// load q
 	movw	r1, #47521
 	movt	r1, #65521
 	vmov	s0, r1		// save q32inv
@@ -313,7 +313,7 @@ jump4divsteps_2:
 	str	r1, [r0, #40]
 	vmov	r0, s1		// reload minusdelta for return value
 	pop	{r1-r11,pc}
-	.p2align	2,,3	
+	.p2align	2,,3
 	.syntax		unified
 	.text
 // void jump4divsteps_1 (int minusdelta, int *M, int *f, int *g);
@@ -321,7 +321,7 @@ jump4divsteps_2:
 	.type	jump4divsteps_1, %function
 jump4divsteps_1:
 	push	{r1-r11,lr}
-	mov	r12, #4591	// load q
+	movw	r12, #4591	// load q
 	movw	r1, #47521
 	movt	r1, #65521
 	vmov	s0, r1		// save q32inv

--- a/interface.py
+++ b/interface.py
@@ -41,6 +41,7 @@ class M4Settings(mupq.PlatformSettings):
         {'scheme': 'rainbowVc-classic', 'implementation': 'clean'},
         {'scheme': 'rainbowVc-cyclic', 'implementation': 'clean'},
         {'scheme': 'rainbowVc-cyclic-compressed', 'implementation': 'clean'},
+        {'scheme': 'mceliece348864', 'implementation': 'clean'},
         {'scheme': 'mceliece348864f', 'implementation': 'clean'},
         {'scheme': 'mceliece460896', 'implementation': 'clean'},
         {'scheme': 'mceliece460896f', 'implementation': 'clean'},


### PR DESCRIPTION
Some older gcc versions complain about mov.w with constants being too large. See #164 
Changing those to movw fixes this.