### PR TITLE
Port Dilithium 3.1 changes to M4 implementation

### DIFF
--- a/crypto_sign/dilithium2/m4/packing.c
+++ b/crypto_sign/dilithium2/m4/packing.c
@@ -64,7 +64,7 @@ void unpack_pk(uint8_t rho[SEEDBYTES],
 **************************************************/
 void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
              const uint8_t rho[SEEDBYTES],
-             const uint8_t tr[CRHBYTES],
+             const uint8_t tr[SEEDBYTES],
              const uint8_t key[SEEDBYTES],
              const polyveck *t0,
              const polyvecl *s1,
@@ -80,9 +80,9 @@ void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
     sk[i] = key[i];
   sk += SEEDBYTES;
 
-  for(i = 0; i < CRHBYTES; ++i)
+  for(i = 0; i < SEEDBYTES; ++i)
     sk[i] = tr[i];
-  sk += CRHBYTES;
+  sk += SEEDBYTES;
 
   for(i = 0; i < L; ++i)
     polyeta_pack(sk + i*POLYETA_PACKEDBYTES, &s1->vec[i]);
@@ -110,7 +110,7 @@ void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
 *              - uint8_t sk[]: byte array containing bit-packed sk
 **************************************************/
 void unpack_sk(uint8_t rho[SEEDBYTES],
-               uint8_t tr[CRHBYTES],
+               uint8_t tr[SEEDBYTES],
                uint8_t key[SEEDBYTES],
                polyveck *t0,
                polyvecl *s1,
@@ -127,9 +127,9 @@ void unpack_sk(uint8_t rho[SEEDBYTES],
     key[i] = sk[i];
   sk += SEEDBYTES;
 
-  for(i = 0; i < CRHBYTES; ++i)
+  for(i = 0; i < SEEDBYTES; ++i)
     tr[i] = sk[i];
-  sk += CRHBYTES;
+  sk += SEEDBYTES;
 
   for(i=0; i < L; ++i)
     polyeta_unpack(&s1->vec[i], sk + i*POLYETA_PACKEDBYTES);

--- a/crypto_sign/dilithium2/m4/packing.h
+++ b/crypto_sign/dilithium2/m4/packing.h
@@ -11,7 +11,7 @@ void pack_pk(uint8_t pk[CRYPTO_PUBLICKEYBYTES], const uint8_t rho[SEEDBYTES], co
 #define pack_sk DILITHIUM_NAMESPACE(pack_sk)
 void pack_sk(uint8_t sk[CRYPTO_SECRETKEYBYTES],
              const uint8_t rho[SEEDBYTES],
-             const uint8_t tr[CRHBYTES],
+             const uint8_t tr[SEEDBYTES],
              const uint8_t key[SEEDBYTES],
              const polyveck *t0,
              const polyvecl *s1,
@@ -25,7 +25,7 @@ void unpack_pk(uint8_t rho[SEEDBYTES], polyveck *t1, const uint8_t pk[CRYPTO_PUB
 
 #define unpack_sk DILITHIUM_NAMESPACE(unpack_sk)
 void unpack_sk(uint8_t rho[SEEDBYTES],
-               uint8_t tr[CRHBYTES],
+               uint8_t tr[SEEDBYTES],
                uint8_t key[SEEDBYTES],
                polyveck *t0,
                polyvecl *s1,

--- a/crypto_sign/dilithium2/m4/params.h
+++ b/crypto_sign/dilithium2/m4/params.h
@@ -7,7 +7,7 @@
 
 
 #define SEEDBYTES 32
-#define CRHBYTES 48
+#define CRHBYTES 64
 #define N 256
 #define Q 8380417
 #define D 13
@@ -71,7 +71,7 @@
 #endif
 
 #define CRYPTO_PUBLICKEYBYTES (SEEDBYTES + K*POLYT1_PACKEDBYTES)
-#define CRYPTO_SECRETKEYBYTES (2*SEEDBYTES + CRHBYTES \
+#define CRYPTO_SECRETKEYBYTES (3*SEEDBYTES \
                                + L*POLYETA_PACKEDBYTES \
                                + K*POLYETA_PACKEDBYTES \
                                + K*POLYT0_PACKEDBYTES)

--- a/crypto_sign/dilithium2/m4/poly.c
+++ b/crypto_sign/dilithium2/m4/poly.c
@@ -410,27 +410,26 @@ static unsigned int rej_eta(int32_t *a,
 *              - uint16_t nonce: 2-byte nonce
 **************************************************/
 #if ETA == 2
-#define POLY_UNIFORM_ETA_NBLOCKS ((136 + STREAM128_BLOCKBYTES - 1)/STREAM128_BLOCKBYTES)
+#define POLY_UNIFORM_ETA_NBLOCKS ((136 + STREAM256_BLOCKBYTES - 1)/STREAM256_BLOCKBYTES)
 #elif ETA == 4
-#define POLY_UNIFORM_ETA_NBLOCKS ((227 + STREAM128_BLOCKBYTES - 1)/STREAM128_BLOCKBYTES)
+#define POLY_UNIFORM_ETA_NBLOCKS ((227 + STREAM256_BLOCKBYTES - 1)/STREAM256_BLOCKBYTES)
 #endif
 void poly_uniform_eta(poly *a,
-                      const uint8_t seed[SEEDBYTES],
-                      uint16_t nonce)
-{
+        const uint8_t seed[CRHBYTES],
+        uint16_t nonce) {
   unsigned int ctr;
-  unsigned int buflen = POLY_UNIFORM_ETA_NBLOCKS*STREAM128_BLOCKBYTES;
-  uint8_t buf[POLY_UNIFORM_ETA_NBLOCKS*STREAM128_BLOCKBYTES];
-  stream128_state state;
+  unsigned int buflen = POLY_UNIFORM_ETA_NBLOCKS * STREAM256_BLOCKBYTES;
+  uint8_t buf[POLY_UNIFORM_ETA_NBLOCKS * STREAM256_BLOCKBYTES];
+  stream256_state state;
 
-  stream128_init(&state, seed, nonce);
-  stream128_squeezeblocks(buf, POLY_UNIFORM_ETA_NBLOCKS, &state);
+  stream256_init(&state, seed, nonce);
+  stream256_squeezeblocks(buf, POLY_UNIFORM_ETA_NBLOCKS, &state);
 
   ctr = rej_eta(a->coeffs, N, buf, buflen);
 
   while(ctr < N) {
-    stream128_squeezeblocks(buf, 1, &state);
-    ctr += rej_eta(a->coeffs + ctr, N - ctr, buf, STREAM128_BLOCKBYTES);
+    stream256_squeezeblocks(buf, 1, &state);
+    ctr += rej_eta(a->coeffs + ctr, N - ctr, buf, STREAM256_BLOCKBYTES);
   }
 }
 

--- a/crypto_sign/dilithium2/m4/poly.h
+++ b/crypto_sign/dilithium2/m4/poly.h
@@ -48,7 +48,7 @@ void poly_uniform(poly *a,
                   uint16_t nonce);
 #define poly_uniform_eta DILITHIUM_NAMESPACE(poly_uniform_eta)
 void poly_uniform_eta(poly *a,
-                      const uint8_t seed[SEEDBYTES],
+                      const uint8_t seed[CRHBYTES],
                       uint16_t nonce);
 #define poly_uniform_gamma1 DILITHIUM_NAMESPACE(poly_uniform_gamma1)
 void poly_uniform_gamma1(poly *a,

--- a/crypto_sign/dilithium2/m4/polyvec.c
+++ b/crypto_sign/dilithium2/m4/polyvec.c
@@ -33,7 +33,7 @@ void polyvec_matrix_pointwise_montgomery(polyveck *t, const polyvecl mat[K], con
 /************ Vectors of polynomials of length L **************/
 /**************************************************************/
 
-void polyvecl_uniform_eta(polyvecl *v, const uint8_t seed[SEEDBYTES], uint16_t nonce) {
+void polyvecl_uniform_eta(polyvecl *v, const uint8_t seed[CRHBYTES], uint16_t nonce) {
   unsigned int i;
 
   for(i = 0; i < L; ++i)
@@ -166,7 +166,7 @@ int polyvecl_chknorm(const polyvecl *v, int32_t bound)  {
 /************ Vectors of polynomials of length K **************/
 /**************************************************************/
 
-void polyveck_uniform_eta(polyveck *v, const uint8_t seed[SEEDBYTES], uint16_t nonce) {
+void polyveck_uniform_eta(polyveck *v, const uint8_t seed[CRHBYTES], uint16_t nonce) {
   unsigned int i;
 
   for(i = 0; i < K; ++i)

--- a/crypto_sign/dilithium2/m4/polyvec.h
+++ b/crypto_sign/dilithium2/m4/polyvec.h
@@ -11,7 +11,7 @@ typedef struct {
 } polyvecl;
 
 #define polyvecl_uniform_eta DILITHIUM_NAMESPACE(polyvecl_uniform_eta)
-void polyvecl_uniform_eta(polyvecl *v, const uint8_t seed[SEEDBYTES], uint16_t nonce);
+void polyvecl_uniform_eta(polyvecl *v, const uint8_t seed[CRHBYTES], uint16_t nonce);
 
 #define polyvecl_uniform_gamma1 DILITHIUM_NAMESPACE(polyvecl_uniform_gamma1)
 void polyvecl_uniform_gamma1(polyvecl *v, const uint8_t seed[CRHBYTES], uint16_t nonce);
@@ -49,7 +49,7 @@ typedef struct {
 } polyveck;
 
 #define polyveck_uniform_eta DILITHIUM_NAMESPACE(polyveck_uniform_eta)
-void polyveck_uniform_eta(polyveck *v, const uint8_t seed[SEEDBYTES], uint16_t nonce);
+void polyveck_uniform_eta(polyveck *v, const uint8_t seed[CRHBYTES], uint16_t nonce);
 
 #define polyveck_reduce DILITHIUM_NAMESPACE(polyveck_reduce)
 void polyveck_reduce(polyveck *v);

--- a/crypto_sign/dilithium2/m4/sign.c
+++ b/crypto_sign/dilithium2/m4/sign.c
@@ -20,8 +20,8 @@
 * Returns 0 (success)
 **************************************************/
 int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
-  uint8_t seedbuf[3*SEEDBYTES];
-  uint8_t tr[CRHBYTES];
+  uint8_t seedbuf[2*SEEDBYTES + CRHBYTES];
+  uint8_t tr[SEEDBYTES];
   const uint8_t *rho, *rhoprime, *key;
   polyvecl mat[K];
   polyvecl s1, s1hat;
@@ -29,10 +29,10 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
 
   /* Get randomness for rho, rhoprime and key */
   randombytes(seedbuf, SEEDBYTES);
-  shake256(seedbuf, 3*SEEDBYTES, seedbuf, SEEDBYTES);
+  shake256(seedbuf, 2*SEEDBYTES + CRHBYTES, seedbuf, SEEDBYTES);
   rho = seedbuf;
-  rhoprime = seedbuf + SEEDBYTES;
-  key = seedbuf + 2*SEEDBYTES;
+  rhoprime = rho + SEEDBYTES;
+  key = rhoprime + CRHBYTES;
 
   /* Expand matrix */
   polyvec_matrix_expand(mat, rho);
@@ -56,8 +56,8 @@ int crypto_sign_keypair(uint8_t *pk, uint8_t *sk) {
   polyveck_power2round(&t1, &t0, &t1);
   pack_pk(pk, rho, &t1);
 
-  /* Compute CRH(rho, t1) and write secret key */
-  crh(tr, pk, CRYPTO_PUBLICKEYBYTES);
+  /* Compute H(rho, t1) and write secret key */
+  shake256(tr, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
   pack_sk(sk, rho, tr, key, &t0, &s1, &s2);
 
   return 0;
@@ -83,7 +83,7 @@ int crypto_sign_signature(uint8_t *sig,
                           const uint8_t *sk)
 {
   unsigned int n;
-  uint8_t seedbuf[2*SEEDBYTES + 3*CRHBYTES];
+  uint8_t seedbuf[3*SEEDBYTES + 2*CRHBYTES];
   uint8_t *rho, *tr, *key, *mu, *rhoprime;
   uint16_t nonce = 0;
   polyvecl mat[K], s1, y, z;
@@ -93,14 +93,14 @@ int crypto_sign_signature(uint8_t *sig,
 
   rho = seedbuf;
   tr = rho + SEEDBYTES;
-  key = tr + CRHBYTES;
+  key = tr + SEEDBYTES;
   mu = key + SEEDBYTES;
   rhoprime = mu + CRHBYTES;
   unpack_sk(rho, tr, key, &t0, &s1, &s2, sk);
 
   /* Compute CRH(tr, msg) */
   shake256_inc_init(&state);
-  shake256_inc_absorb(&state, tr, CRHBYTES);
+  shake256_inc_absorb(&state, tr, SEEDBYTES);
   shake256_inc_absorb(&state, m, mlen);
   shake256_inc_finalize(&state);
   shake256_inc_squeeze(mu, CRHBYTES, &state);
@@ -108,7 +108,7 @@ int crypto_sign_signature(uint8_t *sig,
 #ifdef DILITHIUM_RANDOMIZED_SIGNING
   randombytes(rhoprime, CRHBYTES);
 #else
-  crh(rhoprime, key, SEEDBYTES + CRHBYTES);
+  shake256(rhoprime, CRHBYTES, key, SEEDBYTES + CRHBYTES);
 #endif
 
   /* Expand matrix and transform vectors */
@@ -246,10 +246,10 @@ int crypto_sign_verify(const uint8_t *sig,
   if(polyvecl_chknorm(&z, GAMMA1 - BETA))
     return -1;
 
-  /* Compute CRH(CRH(rho, t1), msg) */
-  crh(mu, pk, CRYPTO_PUBLICKEYBYTES);
+  /* Compute CRH(h(rho, t1), msg) */
+  shake256(mu, SEEDBYTES, pk, CRYPTO_PUBLICKEYBYTES);
   shake256_inc_init(&state);
-  shake256_inc_absorb(&state, mu, CRHBYTES);
+  shake256_inc_absorb(&state, mu, SEEDBYTES);
   shake256_inc_absorb(&state, m, mlen);
   shake256_inc_finalize(&state);
   shake256_inc_squeeze(mu, CRHBYTES, &state);

--- a/crypto_sign/dilithium2/m4/symmetric.h
+++ b/crypto_sign/dilithium2/m4/symmetric.h
@@ -20,7 +20,6 @@ void dilithium_aes256ctr_init(aes256ctr_ctx *state,
 #define STREAM128_BLOCKBYTES AES256CTR_BLOCKBYTES
 #define STREAM256_BLOCKBYTES AES256CTR_BLOCKBYTES
 
-#define crh(OUT, IN, INBYTES) shake256(OUT, CRHBYTES, IN, INBYTES)
 #define stream128_init(STATE, SEED, NONCE) \
         dilithium_aes256ctr_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) \
@@ -52,7 +51,6 @@ void dilithium_shake256_stream_init(stream256_state *state,
 #define STREAM128_BLOCKBYTES SHAKE128_RATE
 #define STREAM256_BLOCKBYTES SHAKE256_RATE
 
-#define crh(OUT, IN, INBYTES) shake256(OUT, CRHBYTES, IN, INBYTES)
 #define stream128_init(STATE, SEED, NONCE) \
         dilithium_shake128_stream_init(STATE, SEED, NONCE)
 #define stream128_squeezeblocks(OUT, OUTBLOCKS, STATE) \

--- a/crypto_sign/dilithium2/m4/vector.s
+++ b/crypto_sign/dilithium2/m4/vector.s
@@ -60,51 +60,6 @@ pqcrystals_dilithium_asm_reduce32:
     caddq \a, \tmp, \q
 .endm
 
-// // void asm_freeze(int32_t a[N]);
-// .global pqcrystals_dilithium_asm_freeze
-// .type pqcrystals_dilithium_asm_freeze, %function
-// .align 2
-// pqcrystals_dilithium_asm_freeze:
-//     push {r4-r10}
-
-//     movw r12,#:lower16:8380417
-//     movt r12,#:upper16:8380417
-
-//     movw r10, #32
-//     1:
-//         ldr.w r1, [r0]
-//         ldr.w r2, [r0, #1*4]
-//         ldr.w r3, [r0, #2*4]
-//         ldr.w r4, [r0, #3*4]
-//         ldr.w r5, [r0, #4*4]
-//         ldr.w r6, [r0, #5*4]
-//         ldr.w r7, [r0, #6*4]
-//         ldr.w r8, [r0, #7*4]
-
-//         freezeq r1, r9, r12
-//         freezeq r2, r9, r12
-//         freezeq r3, r9, r12
-//         freezeq r4, r9, r12
-//         freezeq r5, r9, r12
-//         freezeq r6, r9, r12
-//         freezeq r7, r9, r12
-//         freezeq r8, r9, r12
-
-//         str.w r2, [r0, #1*4]
-//         str.w r3, [r0, #2*4]
-//         str.w r4, [r0, #3*4]
-//         str.w r5, [r0, #4*4]
-//         str.w r6, [r0, #5*4]
-//         str.w r7, [r0, #6*4]
-//         str.w r8, [r0, #7*4]
-//         str r1, [r0], #8*4
-//         subs r10, #1
-//         bne.w 1b
-
-//     pop {r4-r10}
-//     bx lr
-// .size pqcrystals_dilithium_asm_freeze, .-pqcrystals_dilithium_asm_freeze
-
 // void asm_caddq(int32_t a[N]);
 .global pqcrystals_dilithium_asm_caddq
 .type pqcrystals_dilithium_asm_caddq, %function


### PR DESCRIPTION
Dilithium announced changes which result in new testvectors in https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/BjfjRMIdnhM. This pulls the changes from PQClean (PQClean/PQClean#373) and ports the changes to our M4 implementation. 

The performance impact is minimal (copying around a few more bytes and needing a couple more bytes of stack). I'll not run the benchmarks now. 