### PR TITLE
Add support for Nucleo-L4R5ZI board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 all: tests
 
 include mupq/mk/config.mk
+include mk/config.mk
 include mk/crypto.mk
 include mupq/mk/host-crypto.mk
 include mupq/mk/rules.mk

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ boards, all featuring an ARM Cortex-M4 chip:
   separate USB serial interface converter.
 * `cw308t-stm32f3`: The ChipWhisperer [CW308-STM32F3 target board](https://rtfm.newae.com/Targets/UFO%20Targets/CW308T-STM32F/)
   (in the F3 configuration) featuring 256KB of Flash and 40KB of RAM.
+* `nucleo-l4r5zi`: The [NUCLEO-L4R5ZI board](https://www.st.com/en/evaluation-tools/nucleo-l4r5zi.html)
+  featuring 2MB of Flash and 640KB of RAM. This board does not require a
+  separate USB serial interface converter.
 * `mps2-an386`: The ARM MPS2(+) FPGA prototyping board when used with the
   ARM-Cortex M4 bitstream (see [ARM AN386](https://developer.arm.com/documentation/dai0386/c))
   featuring two 4MB RAM blocks, one used in lieu of Flash one as RAM. This board
@@ -60,10 +63,15 @@ On most Linux systems, the correct toolchain gets installed when you install the
 On some Linux distributions, you will also have to explicitly install `libnewlib-arm-none-eabi` .
 
 ### Installing stlink
-To flash binaries onto the development board, **pqm4** is using [stlink](https://github.com/texane/stlink). 
+To flash binaries onto most development boards, **pqm4** is using [stlink](https://github.com/texane/stlink). 
 Depending on your operating system, stlink may be available in your package manager -- if not, please
 refer to the stlink Github page for instructions on how to [compile it from source](https://github.com/texane/stlink/blob/master/doc/compiling.md) 
 (in that case, be careful to use libusb-1.0.0-dev, not libusb-0.1).
+
+### Installing OpenOCD
+For the `nucleo-l4r5zi` board [OpenOCD](http://openocd.org) (tested with version 0.11) is used for flashing binaries.
+Depending on your operating system, OpenOCD may be available in your package manager -- if not, please
+refer to the OpenOCD README for instructions on how to [compile it from source](http://openocd.org/doc-release/README).
 
 ### Python3
 The benchmarking scripts used in **pqm4** require Python >= 3.6.

--- a/common/hal-opencm3.c
+++ b/common/hal-opencm3.c
@@ -61,6 +61,31 @@ const struct rcc_clock_scale benchmarkclock = {
 #define SERIAL_PINS (GPIO9 | GPIO10)
 #define STM32
 #define CW_BOARD
+#elif defined(STM32L4R5ZI)
+#include <libopencm3/stm32/rcc.h>
+#include <libopencm3/stm32/gpio.h>
+#include <libopencm3/stm32/usart.h>
+#include <libopencm3/stm32/flash.h>
+#include <libopencm3/stm32/rng.h>
+#include <libopencm3/stm32/pwr.h>
+
+#define SERIAL_GPIO GPIOG
+#define SERIAL_USART LPUART1
+#define SERIAL_PINS (GPIO8 | GPIO7)
+#define NUCLEO_L4R5_BOARD
+
+/* Patched function for newer PLL not yet supported by opencm3 */
+void _rcc_set_main_pll(uint32_t source, uint32_t pllm, uint32_t plln, uint32_t pllp,
+                       uint32_t pllq, uint32_t pllr)
+{
+	RCC_PLLCFGR = (RCC_PLLCFGR_PLLM(pllm) << RCC_PLLCFGR_PLLM_SHIFT) |
+		(plln << RCC_PLLCFGR_PLLN_SHIFT) |
+		((pllp & 0x1Fu) << 27u) | /* NEWER PLLP */
+		(source << RCC_PLLCFGR_PLLSRC_SHIFT) |
+		(pllq << RCC_PLLCFGR_PLLQ_SHIFT) |
+		(pllr << RCC_PLLCFGR_PLLR_SHIFT) | RCC_PLLCFGR_PLLREN;
+}
+
 #else
 #error Unsupported libopencm3 board
 #endif
@@ -160,6 +185,58 @@ static void clock_setup(enum clock_mode clock)
 
   rcc_periph_clock_enable(RCC_RNG);
   rng_enable();
+#elif defined(NUCLEO_L4R5_BOARD)
+  rcc_periph_clock_enable(RCC_PWR);
+  rcc_periph_clock_enable(RCC_SYSCFG);
+  pwr_set_vos_scale(PWR_SCALE1);
+  switch (clock) {
+  case CLOCK_BENCHMARK:
+    /* Benchmark straight from the HSI16 without prescaling */
+    rcc_osc_on(RCC_HSI16);
+    rcc_wait_for_osc_ready(RCC_HSI16);
+    rcc_ahb_frequency = 16000000;
+    rcc_apb1_frequency = 16000000;
+    rcc_apb2_frequency = 16000000;
+    _clock_freq = 16000000;
+    rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
+    rcc_set_ppre1(RCC_CFGR_PPRE1_NODIV);
+    rcc_set_ppre2(RCC_CFGR_PPRE2_NODIV);
+    flash_dcache_enable();
+    flash_icache_enable();
+    flash_set_ws(FLASH_ACR_LATENCY_0WS);
+    flash_prefetch_enable();
+    rcc_set_sysclk_source(RCC_CFGR_SW_HSI16);
+    rcc_wait_for_sysclk_status(RCC_HSI16);
+    break;
+  case CLOCK_FAST:
+  default:
+    rcc_osc_on(RCC_HSI16);
+    rcc_wait_for_osc_ready(RCC_HSI16);
+    rcc_ahb_frequency = 120000000;
+    rcc_apb1_frequency = 120000000;
+    rcc_apb2_frequency = 120000000;
+    _clock_freq = 120000000;
+    rcc_set_hpre(RCC_CFGR_HPRE_NODIV);
+    rcc_set_ppre1(RCC_CFGR_PPRE1_NODIV);
+    rcc_set_ppre2(RCC_CFGR_PPRE2_NODIV);
+    rcc_osc_off(RCC_PLL);
+    while(rcc_is_osc_ready(RCC_PLL));
+    /* Configure the PLL oscillator (use CUBEMX tool -> scale HSI16 to 120MHz). */
+    _rcc_set_main_pll(RCC_PLLCFGR_PLLSRC_HSI16, 2, 30, 2u, RCC_PLLCFGR_PLLQ_DIV2, RCC_PLLCFGR_PLLR_DIV2);
+    /* Enable PLL oscillator and wait for it to stabilize. */
+    rcc_osc_on(RCC_PLL);
+    rcc_wait_for_osc_ready(RCC_PLL);
+    flash_dcache_enable();
+    flash_icache_enable();
+    flash_set_ws(0x05);
+    flash_prefetch_enable();
+    rcc_set_sysclk_source(RCC_CFGR_SW_PLL);
+    rcc_wait_for_sysclk_status(RCC_PLL);
+    break;
+  }
+  rcc_osc_on(RCC_HSI48); /* HSI48 must always be on for RNG */
+  rcc_periph_clock_enable(RCC_RNG);
+  rng_enable();
 #else
 #error Unsupported platform
 #endif
@@ -176,6 +253,23 @@ void usart_setup()
 #elif defined(NUCLEO_BOARD)
   rcc_periph_clock_enable(RCC_GPIOA);
   rcc_periph_clock_enable(RCC_USART2);
+#elif defined(NUCLEO_L4R5_BOARD)
+  rcc_periph_clock_enable(RCC_GPIOG);
+  rcc_periph_clock_enable(RCC_LPUART1);
+
+  PWR_CR2 |= PWR_CR2_IOSV;
+  gpio_set_output_options(SERIAL_GPIO, GPIO_OTYPE_PP, GPIO_OSPEED_100MHZ, SERIAL_PINS);
+  gpio_set_af(SERIAL_GPIO, GPIO_AF8, SERIAL_PINS);
+  gpio_mode_setup(SERIAL_GPIO, GPIO_MODE_AF, GPIO_PUPD_NONE, SERIAL_PINS);
+  usart_set_baudrate(SERIAL_USART, SERIAL_BAUD);
+  usart_set_databits(SERIAL_USART, 8);
+  usart_set_stopbits(SERIAL_USART, USART_STOPBITS_1);
+  usart_set_mode(SERIAL_USART, USART_MODE_TX_RX);
+  usart_set_parity(SERIAL_USART, USART_PARITY_NONE);
+  usart_set_flow_control(SERIAL_USART, USART_FLOWCONTROL_NONE);
+  usart_disable_rx_interrupt(SERIAL_USART);
+  usart_disable_tx_interrupt(SERIAL_USART);
+  usart_enable(SERIAL_USART);
 #else
 #error Unsupported platform
 #endif

--- a/common/randombytes.c
+++ b/common/randombytes.c
@@ -1,6 +1,6 @@
 #include "randombytes.h"
 
-#if defined(STM32F2) || defined(STM32F4) && !defined(MPS2_AN386)
+#if defined(STM32F2) || defined(STM32F4) || defined(STM32L4R5ZI) && !defined(MPS2_AN386)
 
 #include <libopencm3/stm32/rng.h>
 

--- a/common/test.c
+++ b/common/test.c
@@ -1,10 +1,139 @@
 #include <hal.h>
+#include <randombytes.h>
 #include <sendfn.h>
+#include <stdint.h>
+
+#if defined(SRAM_TIMING_TEST)
+#define TEST_BLOCK_SIZE 4096
+
+/* Don't use opencm3 here, since not all platforms might use opencm3, but all
+   have these DWT registers */
+#define DWT_CTRL           (*(volatile uint32_t*)(0xE0001000u + 0x00))
+#define DWT_CYCCNT         (*(volatile uint32_t*)(0xE0001000u + 0x04))
+#define DWT_CTRL_CYCCNTENA (1 << 0)
+#define SCS_DEMCR          (*(volatile uint32_t*)(0xE000E000u + 0xDFC))
+#define SCS_DEMCR_TRCENA   (1 << 24)
+/* Need a really precise cycle counter. */
+static void cyccnt_enable()
+{
+	SCS_DEMCR |= SCS_DEMCR_TRCENA;
+	DWT_CYCCNT = 0;
+	DWT_CTRL |= DWT_CTRL_CYCCNTENA;
+}
+static inline void cyccnt_start()
+{
+	DWT_CYCCNT = 0;
+}
+static inline uint32_t cyccnt_get()
+{
+  return DWT_CYCCNT;
+}
+
+__attribute__((noinline))
+static uint32_t test_load(volatile unsigned* ram_block)
+{
+  asm volatile("cpsid if");
+  cyccnt_start();
+#define NL "\n\t"
+  asm volatile("_MEMLOOP%=:" NL
+               "ldr r12, [%0], #4" NL
+               "cmp %0, %1" NL
+               "bne _MEMLOOP%=" NL
+               :"+r" (ram_block): "r" (ram_block + (TEST_BLOCK_SIZE / sizeof(unsigned))): "r12", "cc");
+  uint32_t result = cyccnt_get();
+  asm volatile("cpsie if");
+  return result;
+}
+
+__attribute__((noinline))
+static uint32_t test_unalignedload(volatile void* ram_block)
+{
+  volatile unsigned char* ram_block8 = ram_block;
+  ram_block8 += 2;
+  asm volatile("cpsid if");
+  cyccnt_start();
+#define NL "\n\t"
+  asm volatile("_MEMLOOP%=:" NL
+               "ldr r12, [%0], #4" NL
+               "cmp %0, %1" NL
+               "blt _MEMLOOP%=" NL
+               :"+r" (ram_block8): "r" (ram_block8 + TEST_BLOCK_SIZE): "r12", "cc");
+  uint32_t result = cyccnt_get();
+  asm volatile("cpsie if");
+  return result;
+}
+
+__attribute__((noinline))
+static uint32_t test_store(volatile unsigned* ram_block)
+{
+  cyccnt_start();
+#define NL "\n\t"
+  asm volatile("_MEMLOOP%=:" NL
+               "str r12, [%0], #4" NL
+               "cmp %0, %1" NL
+               "bne _MEMLOOP%=" NL
+               :"+r" (ram_block): "r" (ram_block + (TEST_BLOCK_SIZE / sizeof(unsigned))): "r12", "cc");
+  return cyccnt_get();
+}
+
+__attribute__((noinline))
+static uint32_t test_loadstore(volatile unsigned* ram_block)
+{
+  cyccnt_start();
+#define NL "\n\t"
+  asm volatile("_MEMLOOP%=:" NL
+               "str r12, [%0]" NL
+               "add r12, r12, #1" NL
+               "ldr r12, [%0], #4" NL
+               "cmp %0, %1" NL
+               "bne _MEMLOOP%=" NL
+               :"+r" (ram_block): "r" (ram_block + (TEST_BLOCK_SIZE / sizeof(unsigned))): "r12", "cc");
+  return cyccnt_get();
+}
+
+static void memory_timing_test(void)
+{
+  cyccnt_enable();
+#define RAMBLK(BLK)                                                       \
+  static volatile unsigned ram ## BLK ## _block[TEST_BLOCK_SIZE / sizeof(unsigned) + 1] __attribute__((section(".ram" #BLK)))
+
+#define TEST(BLK) \
+  test_load(ram ## BLK ## _block); \
+  test_unalignedload(ram ## BLK ## _block);  \
+  test_store(ram ## BLK ## _block); \
+  test_loadstore(ram ## BLK ## _block); \
+  send_unsigned("ram" #BLK " load", test_load(ram ## BLK ## _block)); \
+  send_unsigned("ram" #BLK " unalignedload", test_unalignedload(ram ## BLK ## _block));   \
+  send_unsigned("ram" #BLK " store", test_store(ram ## BLK ## _block)); \
+  send_unsigned("ram" #BLK " loadstore", test_loadstore(ram ## BLK ## _block));
+
+  static volatile unsigned ram1_block[TEST_BLOCK_SIZE / sizeof(unsigned) + 1];
+  TEST(1);
+#if defined(HAS_SRAM2)
+  RAMBLK(2);
+  TEST(2);
+#endif
+#if defined(HAS_SRAM3)
+  RAMBLK(3);
+  TEST(3);
+#endif
+#if defined(HAS_CCM)
+  static volatile unsigned ramccm_block[TEST_BLOCK_SIZE / sizeof(unsigned) + 1] __attribute__((section(".ccmram")));
+  TEST(ccm);
+#endif
+}
+#endif
 
 int main(void)
 {
   hal_setup(CLOCK_FAST);
   hal_send_str("Hello world");
   send_unsigned("Stack Size", hal_get_stack_size());
+  unsigned rnd;
+  randombytes((unsigned char*) &rnd, sizeof(unsigned));
+  send_unsigned("Random number", rnd);
+#if defined(SRAM_TIMING_TEST)
+  memory_timing_test();
+#endif
   return 0;
 }

--- a/crypto_kem/bikel1/m4f/bike_aes.h
+++ b/crypto_kem/bikel1/m4f/bike_aes.h
@@ -11,7 +11,7 @@
 #pragma once
 #include "defs.h"
 
-#if defined(STM32F4)
+#if defined(PQM4) || defined(MUPQ)
 
 #include "aes.h"
 
@@ -36,7 +36,7 @@ typedef ALIGN(16) struct aes256_key_s {
 
 CLEANUP_FUNC(aes256_key, aes256_key_t)
 
-#if defined(STM32F4)
+#if defined(PQM4) || defined(MUPQ)
 
 typedef aes256ctx aes256_ks_t;
 

--- a/crypto_kem/bikel1/m4f/run_config.h
+++ b/crypto_kem/bikel1/m4f/run_config.h
@@ -4,7 +4,7 @@
 #ifndef _RUN_CONFIG_H_
 #define _RUN_CONFIG_H_
 
-#if defined(STM32F4)
+#if defined(PQM4)
 
 #define _M4_ASM_
 //#define _USE_CCM_IF_STM32F4_   // l1 can run with < 112KB SRAM. no need to use CCM

--- a/crypto_kem/bikel1/m4f/sha.h
+++ b/crypto_kem/bikel1/m4f/sha.h
@@ -30,7 +30,7 @@ bike_static_assert(sizeof(sha384_dgst_t) == SHA384_DGST_BYTES, sha384_dgst_size)
 typedef sha384_dgst_t sha_dgst_t;
 CLEANUP_FUNC(sha_dgst, sha_dgst_t)
 
-#if defined(STM32F4)
+#if defined(PQM4) || defined(MUPQ)
 
 #include "sha2.h"
 

--- a/crypto_kem/bikel3/m4f/bike_aes.h
+++ b/crypto_kem/bikel3/m4f/bike_aes.h
@@ -10,7 +10,7 @@
 #pragma once
 #include "defs.h"
 
-#if defined(STM32F4)
+#if defined(PQM4) || defined(MUPQ)
 
 #include "aes.h"
 
@@ -35,7 +35,7 @@ typedef ALIGN(16) struct aes256_key_s {
 
 CLEANUP_FUNC(aes256_key, aes256_key_t)
 
-#if defined(STM32F4)
+#if defined(PQM4) || defined(MUPQ)
 
 typedef aes256ctx aes256_ks_t;
 

--- a/crypto_kem/bikel3/m4f/run_config.h
+++ b/crypto_kem/bikel3/m4f/run_config.h
@@ -4,7 +4,7 @@
 #ifndef _RUN_CONFIG_H_
 #define _RUN_CONFIG_H_
 
-#if defined(STM32F4)
+#if defined(PQM4)
 
 #define _M4_ASM_
 //#define _USE_CCM_IF_STM32F4_

--- a/crypto_kem/bikel3/m4f/sha.h
+++ b/crypto_kem/bikel3/m4f/sha.h
@@ -30,7 +30,7 @@ bike_static_assert(sizeof(sha384_dgst_t) == SHA384_DGST_BYTES, sha384_dgst_size)
 typedef sha384_dgst_t sha_dgst_t;
 CLEANUP_FUNC(sha_dgst, sha_dgst_t)
 
-#if defined(STM32F4)
+#if defined(PQM4) || defined(MUPQ)
 
 #include "sha2.h"
 

--- a/interface.py
+++ b/interface.py
@@ -10,7 +10,7 @@ def parse_arguments():
         "-p",
         "--platform",
         help="The PQM4 platform",
-        choices=["stm32f4discovery", "nucleo-l476rg", "cw308t-stm32f3", "mps2-an386"],
+        choices=["stm32f4discovery", "nucleo-l476rg", "nucleo-l4r5zi", "cw308t-stm32f3", "mps2-an386"],
         default="stm32f4discovery",
     )
     parser.add_argument(
@@ -36,6 +36,9 @@ def get_platform(args):
     bin_type = 'bin'
     if args.platform in ['stm32f4discovery', 'nucleo-l476rg']:
         platform = platforms.StLink(args.uart)
+    elif args.platform == "nucleo-l4r5zi":
+        bin_type = 'hex'
+        platform = platforms.OpenOCD("st_nucleo_l4r5.cfg", args.uart)
     elif args.platform == "cw308t-stm32f3":
         bin_type = 'hex'
         platform = platforms.ChipWhisperer()
@@ -63,7 +66,8 @@ class M4Settings(mupq.PlatformSettings):
         'stm32f4discovery': 128*1024,
         'nucleo-l476rg': 128*1024,
         'cw308t-stm32f3': 64*1024,
-        'mps2-an386': 4096*1024
+        'mps2-an386': 4096*1024,
+        'nucleo-l4r5zi': 640*1024
     }
 
     def __init__(self, platform, opt="speed", lto=False, aio=False, iterations=1, binary_type='bin'):

--- a/ldscripts/devices.data
+++ b/ldscripts/devices.data
@@ -1,0 +1,4 @@
+# Device otherwise missing from OpenCM3
+
+stm32l4r5zi stm32l4 ROM=2048K RAM=256K RAM3=384K
+stm32l4 END ROM_OFF=0x08000000 RAM_OFF=0x20000000 RAM2_OFF=0x10000000 RAM3_OFF=0x20040000 CPU=cortex-m4 FPU=hard-fpv4-sp-d16

--- a/ldscripts/nucleo-l4r5zi-ramtest.ld
+++ b/ldscripts/nucleo-l4r5zi-ramtest.ld
@@ -1,0 +1,79 @@
+EXTERN(vector_table)
+ENTRY(reset_handler)
+MEMORY
+{
+ rom (rx) : ORIGIN = 0x08000000, LENGTH = 2048K
+ ram (rwx) : ORIGIN = 0x20000000, LENGTH = 192K
+ ram2 (rwx) : ORIGIN = 0x20030000, LENGTH = 64K
+ ram3 (rwx) : ORIGIN = 0x20040000, LENGTH = 384K
+}
+SECTIONS
+{
+ .text : {
+  *(.vectors)
+  . = ALIGN(448);
+  *(.text*)
+  . = ALIGN(4);
+  *(.rodata*)
+  . = ALIGN(4);
+ } >rom
+ .preinit_array : {
+  . = ALIGN(4);
+  __preinit_array_start = .;
+  KEEP (*(.preinit_array))
+  __preinit_array_end = .;
+ } >rom
+ .init_array : {
+  . = ALIGN(4);
+  __init_array_start = .;
+  KEEP (*(SORT(.init_array.*)))
+  KEEP (*(.init_array))
+  __init_array_end = .;
+ } >rom
+ .fini_array : {
+  . = ALIGN(4);
+  __fini_array_start = .;
+  KEEP (*(.fini_array))
+  KEEP (*(SORT(.fini_array.*)))
+  __fini_array_end = .;
+ } >rom
+ .ARM.extab : {
+  *(.ARM.extab*)
+ } >rom
+ .ARM.exidx : {
+  __exidx_start = .;
+  *(.ARM.exidx*)
+  __exidx_end = .;
+ } >rom
+ . = ALIGN(4);
+ _etext = .;
+ .data : {
+  _data = .;
+  *(.data*)
+  . = ALIGN(4);
+  _edata = .;
+ } >ram AT >rom
+ _data_loadaddr = LOADADDR(.data);
+ .bss : {
+  *(.bss*)
+  *(COMMON)
+  . = ALIGN(4);
+  _ebss = .;
+ } >ram
+ .ram1 : {
+ *(.ram1*)
+ . = ALIGN(4);
+ } >ram
+ end = .;
+ .ram2 : {
+ *(.ram2*)
+ . = ALIGN(4);
+ } >ram2
+ .ram3 : {
+  *(.ram3*)
+  . = ALIGN(4);
+ } >ram3
+ /DISCARD/ : { *(.eh_frame) }
+ . = ALIGN(4);
+}
+PROVIDE(_stack = ORIGIN(ram) + LENGTH(ram));

--- a/ldscripts/nucleo-l4r5zi.ld
+++ b/ldscripts/nucleo-l4r5zi.ld
@@ -1,0 +1,65 @@
+EXTERN(vector_table)
+ENTRY(reset_handler)
+MEMORY
+{
+ rom (rx) : ORIGIN = 0x08000000, LENGTH = 2048K
+ ram (rwx) : ORIGIN = 0x20000000, LENGTH = 640K
+}
+SECTIONS
+{
+ .text : {
+  *(.vectors)
+  . = ALIGN(448);
+  *(.text*)
+  . = ALIGN(4);
+  *(.rodata*)
+  . = ALIGN(4);
+ } >rom
+ .preinit_array : {
+  . = ALIGN(4);
+  __preinit_array_start = .;
+  KEEP (*(.preinit_array))
+  __preinit_array_end = .;
+ } >rom
+ .init_array : {
+  . = ALIGN(4);
+  __init_array_start = .;
+  KEEP (*(SORT(.init_array.*)))
+  KEEP (*(.init_array))
+  __init_array_end = .;
+ } >rom
+ .fini_array : {
+  . = ALIGN(4);
+  __fini_array_start = .;
+  KEEP (*(.fini_array))
+  KEEP (*(SORT(.fini_array.*)))
+  __fini_array_end = .;
+ } >rom
+ .ARM.extab : {
+  *(.ARM.extab*)
+ } >rom
+ .ARM.exidx : {
+  __exidx_start = .;
+  *(.ARM.exidx*)
+  __exidx_end = .;
+ } >rom
+ . = ALIGN(4);
+ _etext = .;
+ .data : {
+  _data = .;
+  *(.data*)
+  . = ALIGN(4);
+  _edata = .;
+ } >ram AT >rom
+ _data_loadaddr = LOADADDR(.data);
+ .bss : {
+  *(.bss*)
+  *(COMMON)
+  . = ALIGN(4);
+  _ebss = .;
+ } >ram
+ end = .;
+ /DISCARD/ : { *(.eh_frame) }
+ . = ALIGN(4);
+}
+PROVIDE(_stack = ORIGIN(ram) + LENGTH(ram));

--- a/ldscripts/stm32f4discovery.ld
+++ b/ldscripts/stm32f4discovery.ld
@@ -3,6 +3,7 @@ ENTRY(reset_handler)
 MEMORY
 {
  ram (rwx) : ORIGIN = 0x20000000, LENGTH = 112K
+ ram2 (rwx) : ORIGIN = 0x2001c000, LENGTH = 16K
  rom (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
  ccm (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
 }
@@ -58,6 +59,10 @@ SECTIONS
   . = ALIGN(4);
   _ebss = .;
  } >ram
+ .ram2 : {
+  *(.ram2*)
+  . = ALIGN(4);
+ } >ram2
  .ccm : {
   *(.ccmram*)
   . = ALIGN(4);

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1,0 +1,2 @@
+CPPFLAGS += \
+	-DPQM4

--- a/mk/mps2-an386.mk
+++ b/mk/mps2-an386.mk
@@ -46,8 +46,6 @@ $(LDSCRIPT): common/mps2/MPS2.ld
 
 $(LDSCRIPT): CPPFLAGS += -Icommon/mps2
 
-elf/crypto_kem_bike%.elf: CPPFLAGS += -DSTM32F4
-
 LINKDEPS += $(LDSCRIPT) $(LIBDEPS)
 
 ENABLE_QEMU_TESTS = 1

--- a/mk/nucleo-l4r5zi.mk
+++ b/mk/nucleo-l4r5zi.mk
@@ -1,0 +1,13 @@
+DEVICE=stm32l4r5zi
+
+EXCLUDED_SCHEMES = \
+	mupq/pqclean/crypto_kem/mceliece% \
+  mupq/crypto_sign/falcon-1024-tree% \
+  mupq/pqclean/crypto_sign/rainbow%
+
+DEVICES_DATA := ldscripts/devices.data
+
+elf/boardtest.elf: CPPFLAGS+=-DSRAM_TIMING_TEST -DHAS_SRAM2 -DHAS_SRAM3
+elf/boardtest.elf: LDSCRIPT=ldscripts/$(PLATFORM)-ramtest.ld
+
+include mk/opencm3.mk

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -23,7 +23,7 @@ ifeq ($(DEVICE),)
 $(warning no DEVICE specified for linker script generator)
 endif
 
-DEVICES_DATA = $(OPENCM3_DIR)/ld/devices.data
+DEVICES_DATA ?= $(OPENCM3_DIR)/ld/devices.data
 
 genlink_family		:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) FAMILY)
 genlink_subfamily	:=$(shell $(OPENCM3_DIR)/scripts/genlink.py $(DEVICES_DATA) $(DEVICE) SUBFAMILY)
@@ -60,7 +60,7 @@ LIBDEPS += $(OPENCM3_DIR)/lib/lib$(LIBNAME).a
 LDFLAGS += -L$(OPENCM3_DIR)/lib
 CPPFLAGS += -I$(OPENCM3_DIR)/include
 
-$(OPENCM3_DIR)/lib/lib$(LIBNAME).a: $(CONFIG)
+$(OPENCM3_DIR)/lib/lib$(LIBNAME).a:
 	$(MAKE) -C $(OPENCM3_DIR)
 
 obj/common/hal-opencm3.c.o: $(OPENCM3_DIR)/lib/lib$(LIBNAME).a

--- a/mk/stm32f4discovery.mk
+++ b/mk/stm32f4discovery.mk
@@ -7,5 +7,7 @@ EXCLUDED_SCHEMES = \
 
 include mk/opencm3.mk
 
+elf/boardtest.elf: CPPFLAGS+=-DSRAM_TIMING_TEST -DHAS_SRAM2 -DHAS_CCM
+
 elf/crypto_kem_frodokem640aes_m4_%.elf: LDSCRIPT=ldscripts/stm32f4discovery_fullram.ld
 elf/mupq_pqclean_crypto_kem_frodokem640shake_opt_%.elf: LDSCRIPT=ldscripts/stm32f4discovery_fullram.ld

--- a/st_nucleo_l4r5.cfg
+++ b/st_nucleo_l4r5.cfg
@@ -1,0 +1,9 @@
+# This is for STM32L4R5 Nucleo Dev Boards.
+source [find interface/stlink-dap.cfg]
+
+transport select dapdirect_swd
+
+source [find target/stm32l4x.cfg]
+
+# use hardware reset (srst seems to be problematic)
+reset_config trst_only


### PR DESCRIPTION
This adds support for Nucleo-L4R5ZI board, a fairly large (in terms of 640KB of SRAM) Cortex-M4 based board. This also includes a memory timing test (used to determine the memory timings of the board), and a small fix for the `bikel{1,3}` source (they checked for `STM32F4` definition, which isn't defined for this or any other non STM32F4 board).

Maybe one point that needs discussion is the memory layout of the board. The board has three SRAMs, all in one continuous address space:

- SRAM1: 192KB
- SRAM2: 64KB
- SRAM3: 384KB

The memory timing test showed that the first SRAM1 block has slightly faster load timings. This is a similar situation as with the STM32F4-Discovery board: There, first SRAM block also has faster timings than the second one (maybe a general situation for the Cortex-M4?). Only in that case, the second block isn't much of a loss with 16KB. Here, we can't just ditch any of the blocks without losing a huge chunk of memory. In most cases, this should be fine, as the tests usually put all LUTs in flash or the stack. However, as soon as a LUT or similar object overlaps  SRAM1/2, there might be a timing side-channel. Not the end of the world for a benchmarking platform, but still annoying. For now I just use the entire RAM as one large block, mostly to have a physical platform with a lot of memory. Timings should be expected to be slightly slower than the STM32F4-Discovery, as most operations would use the SRAM2/3 (as the stack is there), which exhibits slightly worse timings in for loads.

To flash the board, you'll need at least OpenOCD 0.11. Also included is a custom openocd script, since the board appears to have a different reset procedure than most other Nucleo/Discovery boards. While `st-util` can flash this board, it will in some cases end up in a weird reset state and hang. The openocd variant works reliably for me.