### PR TITLE
Restore build_everything.py and add default uart

### DIFF
--- a/build_everything.py
+++ b/build_everything.py
@@ -4,9 +4,12 @@ Builds all of the binaries without flashing them.
 """
 import sys
 
-from interface import M4Settings
+from interface import parse_arguments, get_platform
 from mupq import mupq
 
 
 if __name__ == "__main__":
-    mupq.BuildAll(M4Settings()).test_all(sys.argv[1:])
+    args, rest = parse_arguments()
+    platform, settings = get_platform(args)
+    with platform:
+        mupq.BuildAll(settings).test_all(rest)

--- a/interface.py
+++ b/interface.py
@@ -26,7 +26,7 @@ def parse_arguments():
     parser.add_argument(
         "--no-aio", help="Disable all-in-one compilation", default=False, action="store_true"
     )
-    parser.add_argument("-u", "--uart", help="Path to UART output")
+    parser.add_argument("-u", "--uart", default="/dev/ttyUSB0", help="Path to UART output")
     parser.add_argument("-i", "--iterations", default=1, help="Number of iterations for benchmarks")
     return parser.parse_known_args()
 


### PR DESCRIPTION
The previous version of pqm4 had a build everything script that would spit out
all the binaries.
With the multiplatform pqm4, this is no longer needed. One can simply
`make -j4 PLATFORM=stm32f4discovery`
However, we currently still have a non-functional build_everything.py script
sitting around. I've fixed it, but we could also remove it.

Additionally, to allow users to simply run ./test.py, I added a default uart
device "/dev/ttyUSB0". The old pqm4 also assumed that serial device.
Right now pqm4 miserably fails without a --uart argument and a reasonable
error message.