### PR TITLE
Fixes bug in ntrup761/ntrulpr761 decapssulation

### DIFF
--- a/crypto_kem/sntrup761/m4f/kem.c
+++ b/crypto_kem/sntrup761/m4f/kem.c
@@ -1096,7 +1096,6 @@ static void Encap(unsigned char *c,unsigned char *k,const unsigned char *pk)
 **************************************************/
 static int Ciphertexts_diff_mask(const unsigned char *c,const unsigned char *c2)
 {
-  uint16 differentbits = 0;
   int len = Ciphertexts_bytes+Confirm_bytes;
 
   int *cc = (int *)(void *)c;
@@ -1109,7 +1108,7 @@ static int Ciphertexts_diff_mask(const unsigned char *c,const unsigned char *c2)
   c2 = (unsigned char *)(void *) cc2;
   for (len &= 3; len > 0; len--)
     differentbits2 =__USADA8((*c++),(*c2++),differentbits2);
-  return ((-1)-((differentbits-1)>>31));
+  return ((-1)-((differentbits2-1)>>31));
 }
 
 /*************************************************


### PR DESCRIPTION
#195 reports that the Ciphertexts_diff_mask in kem.c of ntrup761/ntrulpr761 looks obviously wrong. 
I applied to the suggested patch.
The bug was introduced in #150 which integrated the code from https://eprint.iacr.org/2019/100.pdf.