### PR TITLE
Change licensing for Dilithium NTT

### DIFF
--- a/crypto_sign/dilithium2/m4/ntt.s
+++ b/crypto_sign/dilithium2/m4/ntt.s
@@ -1,17 +1,3 @@
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-
 // author: Markus Krausz
 // date: 18.03.18
 
@@ -19,6 +5,7 @@
 // added by Marco Palumbi (marco@palumbi.it)
 // date: 21.12.20
 
+// date 23.07.21: Now licensed under CC0 with permission of the authors.
 .syntax unified
 
 


### PR DESCRIPTION
Closes #198

The Dilithium NTT code was previously licensed under GPL-3.0. The authors have agreed to license it under CC0 so that it is in line with the rest of the code. 