### PR TITLE
Fix minor bug in Kyber

### DIFF
--- a/crypto_kem/kyber512/m4/indcpa.c
+++ b/crypto_kem/kyber512/m4/indcpa.c
@@ -57,7 +57,7 @@ static void matacc(poly* r, polyvec *b, unsigned char i, const unsigned char *se
         }
       }
 
-      if (val1 < KYBER_Q && ctr < KYBER_Q/4) {
+      if (val1 < KYBER_Q && ctr < KYBER_N/4) {
         c[k++] = (int16_t) val1;
         if (k == 4) {
           doublebasemul_asm_acc(&r->coeffs[4*ctr], &b->vec[j].coeffs[4*ctr], c, zetas[ctr]);
@@ -66,7 +66,7 @@ static void matacc(poly* r, polyvec *b, unsigned char i, const unsigned char *se
         }
       }
 
-      if (pos + 3 > buflen && ctr < KYBER_Q/4) {
+      if (pos + 3 > buflen && ctr < KYBER_N/4) {
         off = buflen % 3;
         for(l = 0; l < off; l++)
           buf[l] = buf[buflen - off + l];

--- a/crypto_kem/kyber768/m4/indcpa.c
+++ b/crypto_kem/kyber768/m4/indcpa.c
@@ -57,7 +57,7 @@ static void matacc(poly* r, polyvec *b, unsigned char i, const unsigned char *se
         }
       }
 
-      if (val1 < KYBER_Q && ctr < KYBER_Q/4) {
+      if (val1 < KYBER_Q && ctr < KYBER_N/4) {
         c[k++] = (int16_t) val1;
         if (k == 4) {
           doublebasemul_asm_acc(&r->coeffs[4*ctr], &b->vec[j].coeffs[4*ctr], c, zetas[ctr]);
@@ -66,7 +66,7 @@ static void matacc(poly* r, polyvec *b, unsigned char i, const unsigned char *se
         }
       }
 
-      if (pos + 3 > buflen && ctr < KYBER_Q/4) {
+      if (pos + 3 > buflen && ctr < KYBER_N/4) {
         off = buflen % 3;
         for(l = 0; l < off; l++)
           buf[l] = buf[buflen - off + l];


### PR DESCRIPTION
Fixes two minor bugs in matacc. They did (luckily) not actually result in wrong
outputs.

In the uniform sampling, we use 3 bytes to sample 2 coefficients. In
case the sampled coefficient is too large, we throw it away.
Once we sampled 256 coefficients it is possible that we still have one
coefficient left which needs to be discarded.
The check if we are at the end of a polynomial already was wrongly
implemented by checking for `ctr < KYBER_Q/4` rather than `ctr < KYBER_N/4`
in two places.

Luckily, it has no effect in both cases.
In the first, `ctr = KYBER_N/4` implies k=0 and hence the code does
nothing.
In the second, an additional Keccak squeeze is triggered, but the output
is never used.

This bug was introduced in https://github.com/mupq/pqm4/pull/172/commits/a1cb9e2f1d1ea344207f8502f2547b150e9e0c11 when updating to round 3 code.

Thanks to Amin Abdulrahman for pointing this out!

