### PR TITLE
Remove redundant packing of signature component 'z' in Dilithium

### DIFF
--- a/crypto_sign/dilithium2/m4f/sign.c
+++ b/crypto_sign/dilithium2/m4f/sign.c
@@ -165,7 +165,6 @@ rej:
   unsigned int hints_written = 0;
   /* Check that subtracting cs2 does not change high bits of w and low bits
    * do not reveal secret information */
-  pack_sig_z(sig, &z);
   for(unsigned int i = 0; i < K; ++i) {
     poly *tmp = &z.vec[0];
     poly_small_basemul_invntt(tmp, &cp_small, &cp_small_prime, &s2_prime[i]);


### PR DESCRIPTION
Dear pqm4 team,

I realized that the packing of the signature component 'z' into the output buffer 'sig' was done twice during the Dilithium signing process.
It simply looks as a slight blunder to me, so I simply removed the redundant second function call.

Cheers,
Alexandre