### PR TITLE
Fix function call from assembly

### DIFF
--- a/crypto_kem/kyber768-90s/m4fspeed/matacc.h
+++ b/crypto_kem/kyber768-90s/m4fspeed/matacc.h
@@ -5,11 +5,58 @@
 #include "symmetric.h"
 
 extern void matacc_asm_cache_16_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state, int16_t *aprimeptr, unsigned int *buflen);
+static inline void _matacc_asm_cache_16_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state, int16_t *aprimeptr, unsigned int *buflen)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s26", "s27", "s28", "s29");
+  matacc_asm_cache_16_32(r_tmp, b, c, buf, _zetas, state, aprimeptr, buflen);
+}
+#define matacc_asm_cache_16_32 _matacc_asm_cache_16_32
+
 extern void matacc_asm_cache_32_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state, int16_t *aprimeptr, unsigned int *buflen);
+static inline void _matacc_asm_cache_32_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state, int16_t *aprimeptr, unsigned int *buflen)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s26", "s27", "s28", "s29");
+  matacc_asm_cache_32_32(r_tmp, b, c, buf, _zetas, state, aprimeptr, buflen);
+}
+#define matacc_asm_cache_32_32 _matacc_asm_cache_32_32
+
 extern void matacc_asm_cache_32_16(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state, int16_t *aprimeptr, int32_t *r_tmp, unsigned int *buflen);
+static inline void _matacc_asm_cache_32_16(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state, int16_t *aprimeptr, int32_t *r_tmp, unsigned int *buflen)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s26", "s27", "s28", "s29");
+  matacc_asm_cache_32_16(r, b, c, buf, _zetas, state, aprimeptr, r_tmp, buflen);
+}
+#define matacc_asm_cache_32_16 _matacc_asm_cache_32_16
+
 extern void matacc_asm_opt_16_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr, unsigned int *buflen);
+static inline void _matacc_asm_opt_16_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr, unsigned int *buflen)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s26", "s27", "s28", "s29");
+  matacc_asm_opt_16_32(r_tmp, b, c, buf, state, aprimeptr, buflen);
+}
+#define matacc_asm_opt_16_32 _matacc_asm_opt_16_32
+
 extern void matacc_asm_opt_32_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr, unsigned int *buflen);
+static inline void _matacc_asm_opt_32_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr, unsigned int *buflen)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s26", "s27", "s28", "s29");
+  matacc_asm_opt_32_32(r_tmp, b, c, buf, state, aprimeptr, buflen);
+}
+#define matacc_asm_opt_32_32 _matacc_asm_opt_32_32
+
 extern void matacc_asm_opt_32_16(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr, int32_t *r_tmp, unsigned int *buflen);
+static inline void _matacc_asm_opt_32_16(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr, int32_t *r_tmp, unsigned int *buflen)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s26", "s27", "s28", "s29");
+  matacc_asm_opt_32_16(r, b, c, buf, state, aprimeptr, r_tmp, buflen);
+}
+#define matacc_asm_opt_32_16 _matacc_asm_opt_32_16
 
 void matacc_opt32(poly* r, const polyvec *b, const polyvec *b_prime, unsigned char i, const unsigned char *seed, int transposed);
 void matacc_cache32(poly* r, const polyvec *b, polyvec *b_prime, unsigned char i, const unsigned char *seed, int transposed);

--- a/crypto_kem/kyber768-90s/m4fspeed/matacc_asm.S
+++ b/crypto_kem/kyber768-90s/m4fspeed/matacc_asm.S
@@ -9,7 +9,7 @@
 .macro update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, buflenval
   // if (pos + 3 > buflen 
   vmov \tmp2, \buflenval // get buflen value
-  vmov \tmp, s1
+  vmov \tmp, s17
   sub \tmp3, \bufptr, \tmp // compute pos
   add \tmp3, #3 // pos + 3
   cmp.w \tmp3, \tmp2
@@ -28,29 +28,29 @@
     add.w \tmp, \tmp, \tmp3
     
     // compute buflen
-    vmov \val0, s1 // get buf addr
+    vmov \val0, s17 // get buf addr
     sub \val0, tmp, \val0
     add.w \val0, #64 // XOF_BLOCKBYTES=64
     vmov \buflenval, \val0
     
-    vmov s2, r0
-    vmov s3, r1
-    vmov s4, r2
-    vmov s6, r12
-    vmov s7, lr
+    vmov s18, r0
+    vmov s19, r1
+    vmov s20, r2
+    vmov s22, r12
+    vmov s23, lr
     
     mov.w r0, \tmp // buf + off implicitly after copying loop
     mov r1, #1
-    vmov r2, s10 // get state ptr
+    vmov r2, s26 // get state ptr
     bl aes256xof_squeezeblocks
     
-    vmov r0, s2
-    vmov r1, s3
-    vmov r2, s4
-    vmov r12, s6
-    vmov lr, s7
+    vmov r0, s18
+    vmov r1, s19
+    vmov r2, s20
+    vmov r12, s22
+    vmov lr, s23
     // pos = 0;
-    vmov \bufptr, s1 // reset buffer pointer to start -> only after squeezeblocks
+    vmov \bufptr, s17 // reset buffer pointer to start -> only after squeezeblocks
   3:
 
   cmp \ctr, #256/4
@@ -83,20 +83,20 @@ matacc_asm_cache_16_32:
   
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #15*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s13, tmp2
+  vmov s29, tmp2
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -105,7 +105,7 @@ matacc_asm_cache_16_32:
     
     second_if doublebasemul_asm_cache_16_32, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, zetaptr, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s13
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s29
 
   pop {r0-r11, pc}
 .size matacc_asm_cache_16_32, . - matacc_asm_cache_16_32
@@ -136,20 +136,20 @@ matacc_asm_cache_32_32:
   
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #15*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s13, tmp2
+  vmov s29, tmp2
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -158,7 +158,7 @@ matacc_asm_cache_32_32:
     
     second_if doublebasemul_asm_acc_cache_32_32, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, zetaptr, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s13
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s29
 
   pop {r0-r11, pc}
 .size matacc_asm_cache_32_32, . - matacc_asm_cache_32_32
@@ -190,24 +190,24 @@ matacc_asm_cache_32_16:
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
 
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #15*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
-  vmov s12, rptr // store "real" destinaton in FP
-  vmov s13, rptr // backup
+  vmov s28, rptr // store "real" destinaton in FP
+  vmov s29, rptr // backup
   ldr.w rptr, [sp, #16*4] 
   
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s15, tmp2
+  vmov s31, tmp2
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -216,9 +216,9 @@ matacc_asm_cache_32_16:
 
     second_if doublebasemul_asm_acc_cache_32_16, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, zetaptr, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s15
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s31
 
-  vmov rptr, s13
+  vmov rptr, s29
 
   pop {r0-r11, pc}
 .size matacc_asm_cache_32_16, . - matacc_asm_cache_32_16
@@ -253,20 +253,20 @@ matacc_asm_opt_16_32:
   movt qqinv, #3327
   
   ldr.w tmp, [sp, #13*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #14*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s13, tmp2
+  vmov s29, tmp2
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -275,7 +275,7 @@ matacc_asm_opt_16_32:
 
     second_if doublebasemul_asm_opt_16_32, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, tmp4, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s13
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s29
 
   pop {r0-r11, pc}
 .size matacc_asm_opt_16_32, . - matacc_asm_opt_16_32
@@ -309,20 +309,20 @@ matacc_asm_opt_32_32:
   movt qqinv, #3327
   
   ldr.w tmp, [sp, #13*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #14*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s13, tmp2
+  vmov s29, tmp2
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -331,7 +331,7 @@ matacc_asm_opt_32_32:
     
     second_if doublebasemul_asm_acc_opt_32_32, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, tmp4, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s13
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s29
 
   pop {r0-r11, pc}
 .size matacc_asm_opt_32_32, . - matacc_asm_opt_32_32
@@ -365,24 +365,24 @@ matacc_asm_opt_32_16:
   movt qqinv, #3327
   
   ldr.w tmp, [sp, #13*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #14*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
-  vmov s12, rptr // store "real" destinaton in FP
-  vmov s13, rptr // backup
+  vmov s28, rptr // store "real" destinaton in FP
+  vmov s29, rptr // backup
   ldr.w rptr, [sp, #15*4] 
   
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s15, tmp2
+  vmov s31, tmp2
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -391,9 +391,9 @@ matacc_asm_opt_32_16:
     
     second_if doublebasemul_asm_acc_opt_32_16, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, tmp4, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s15
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s31
 
-  vmov rptr, s13
+  vmov rptr, s29
 
   pop {r0-r11, pc}
 .size matacc_asm_opt_32_16, . - matacc_asm_opt_32_16

--- a/crypto_kem/kyber768-90s/m4fspeed/matacc_asm.S
+++ b/crypto_kem/kyber768-90s/m4fspeed/matacc_asm.S
@@ -200,7 +200,7 @@ matacc_asm_cache_32_16:
   ldr.w rptr, [sp, #16*4] 
   
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s31, tmp2
+  vmov s16, tmp2
 
   movw q, #3329
   movw k, #0
@@ -216,7 +216,7 @@ matacc_asm_cache_32_16:
 
     second_if doublebasemul_asm_acc_cache_32_16, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, zetaptr, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s31
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s16
 
   vmov rptr, s29
 
@@ -375,7 +375,7 @@ matacc_asm_opt_32_16:
   ldr.w rptr, [sp, #15*4] 
   
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s31, tmp2
+  vmov s16, tmp2
 
   movw q, #3329
   movw k, #0
@@ -391,7 +391,7 @@ matacc_asm_opt_32_16:
     
     second_if doublebasemul_asm_acc_opt_32_16, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, tmp4, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s31
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s16
 
   vmov rptr, s29
 

--- a/crypto_kem/kyber768-90s/m4fstack/matacc.h
+++ b/crypto_kem/kyber768-90s/m4fstack/matacc.h
@@ -5,7 +5,22 @@
 #include "symmetric.h"
 
 extern void matacc_asm(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state, unsigned int *buflen);
+static inline void _matacc_asm(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state, unsigned int *buflen)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s26", "s27");
+  matacc_asm(r, b, c, buf,_zetas, state, buflen);
+}
+#define matacc_asm _matacc_asm
+
 extern void matacc_asm_acc(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state, unsigned int *buflen);
+static inline void _matacc_asm_acc(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state, unsigned int *buflen)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s17", "s18", "s19", "s20", "s21", "s22", "s23", "s26", "s27");
+  matacc_asm_acc(r, b, c, buf,_zetas, state, buflen);
+}
+#define matacc_asm_acc _matacc_asm_acc
 
 void matacc(poly* r, const polyvec *b, unsigned char i, const unsigned char *seed, int transposed);
 #endif

--- a/crypto_kem/kyber768-90s/m4fstack/matacc_asm.S
+++ b/crypto_kem/kyber768-90s/m4fstack/matacc_asm.S
@@ -8,7 +8,7 @@
 .macro update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, buflenval
   // if (pos + 3 > buflen 
   vmov \tmp2, \buflenval // get buflen value
-  vmov \tmp, s1
+  vmov \tmp, s17
   sub \tmp3, \bufptr, \tmp // compute pos
   add \tmp3, #3 // pos + 3
   cmp.w \tmp3, \tmp2
@@ -27,29 +27,29 @@
     add \tmp, \tmp, \tmp3
     
     // compute buflen
-    vmov \val0, s1 // get buf addr
+    vmov \val0, s17 // get buf addr
     sub \val0, tmp, \val0
     add.w \val0, #64 // XOF_BLOCKBYTES=64
     vmov \buflenval, \val0
     
-    vmov s2, r0
-    vmov s3, r1
-    vmov s4, r2
-    vmov s6, r12
-    vmov s7, lr
+    vmov s18, r0
+    vmov s19, r1
+    vmov s20, r2
+    vmov s22, r12
+    vmov s23, lr
     
     mov r0, \tmp // buf + off implicitly after copying loop
     mov r1, #1
-    vmov r2, s10 // get state ptr
+    vmov r2, s26 // get state ptr
     bl aes256xof_squeezeblocks
     
-    vmov r0, s2
-    vmov r1, s3
-    vmov r2, s4
-    vmov r12, s6
-    vmov lr, s7
+    vmov r0, s18
+    vmov r1, s19
+    vmov r2, s20
+    vmov r12, s22
+    vmov lr, s23
     // pos = 0;
-    vmov \bufptr, s1 // reset buffer pointer to start -> only after squeezeblocks
+    vmov \bufptr, s17 // reset buffer pointer to start -> only after squeezeblocks
   3:
 
   cmp \ctr, #256/4
@@ -82,17 +82,17 @@ matacc_asm:
   
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s11, tmp2
+  vmov s27, tmp2
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -101,7 +101,7 @@ matacc_asm:
     
     second_if doublebasemul_asm, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, zetaptr, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s11
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s27
   pop {r0-r11, pc}
 .size matacc_asm, . - matacc_asm
 
@@ -131,17 +131,17 @@ matacc_asm_acc:
   
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
   
   movw tmp2, #64 // XOF_BLOCKBYTES
-  vmov s11, tmp2
+  vmov s27, tmp2
   
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -150,7 +150,7 @@ matacc_asm_acc:
     
     second_if doublebasemul_asm_acc, tmp, tmp2, tmp3, val0, val1, rptr, bptr, cptr, bufptr, zetaptr, k, q, qqinv, ctr
 
-    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s11
+    update_buf_loop_finish tmp, tmp2, tmp3, val0, val1, bufptr, ctr, s27
 
   pop {r0-r11, pc}
 .size matacc_asm_acc, . - matacc_asm_acc

--- a/crypto_kem/kyber768/m4fspeed/matacc.h
+++ b/crypto_kem/kyber768/m4fspeed/matacc.h
@@ -5,11 +5,58 @@
 #include "symmetric.h"
 
 extern void matacc_asm_cache_16_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state, int16_t *aprimeptr);
+static inline void _matacc_asm_cache_16_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state, int16_t *aprimeptr)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s26", "s27", "s28", "s29");
+  matacc_asm_cache_16_32(r_tmp, b, c, buf, _zetas, state, aprimeptr);
+}
+#define matacc_asm_cache_16_32 _matacc_asm_cache_16_32
+
 extern void matacc_asm_cache_32_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state, int16_t *aprimeptr);
+static inline void _matacc_asm_cache_32_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state, int16_t *aprimeptr)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s26", "s27", "s28", "s29");
+  matacc_asm_cache_32_32(r_tmp, b, c, buf, _zetas, state, aprimeptr);
+}
+#define matacc_asm_cache_32_32 _matacc_asm_cache_32_32
+
 extern void matacc_asm_cache_32_16(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state, int16_t *aprimeptr, const int32_t *r_tmp);
+static inline void _matacc_asm_cache_32_16(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state, int16_t *aprimeptr, const int32_t *r_tmp)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s26", "s27", "s28", "s29");
+  matacc_asm_cache_32_16(r, b, c, buf, _zetas, state, aprimeptr, r_tmp);
+}
+#define matacc_asm_cache_32_16 _matacc_asm_cache_32_16
+
 extern void matacc_asm_opt_16_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr);
+static inline void _matacc_asm_opt_16_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s26", "s27", "s28", "s29");
+  matacc_asm_opt_16_32(r_tmp, b, c, buf, state, aprimeptr);
+}
+#define matacc_asm_opt_16_32 _matacc_asm_opt_16_32
+
 extern void matacc_asm_opt_32_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr);
+static inline void _matacc_asm_opt_32_32(int32_t *r_tmp, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s26", "s27", "s28", "s29");
+  matacc_asm_opt_32_32(r_tmp, b, c, buf, state, aprimeptr);
+}
+#define matacc_asm_opt_32_32 _matacc_asm_opt_32_32
+
 extern void matacc_asm_opt_32_16(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr, const int32_t *r_tmp);
+static inline void _matacc_asm_opt_32_16(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], xof_state *state, const int16_t *aprimeptr, const int32_t *r_tmp)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s26", "s27", "s28", "s29");
+  matacc_asm_opt_32_16(r, b, c, buf, state, aprimeptr, r_tmp);
+}
+#define matacc_asm_opt_32_16 _matacc_asm_opt_32_16
 
 void matacc_opt32(poly* r, const polyvec *b, const polyvec *b_prime, unsigned char i, const unsigned char *seed, int transposed);
 void matacc_cache32(poly* r, const polyvec *b, polyvec *b_prime, unsigned char i, const unsigned char *seed, int transposed);

--- a/crypto_kem/kyber768/m4fspeed/matacc.i
+++ b/crypto_kem/kyber768/m4fspeed/matacc.i
@@ -9,15 +9,15 @@
     cmp.w \k, #4
     bne.w 2f
         sub \cptr, #4*2
-        vmov s2, \bufptr
-        vmov s3, \q
-        vmov s4, \ctr
-        vmov s5, \val1
+        vmov s18, \bufptr
+        vmov s19, \q
+        vmov s20, \ctr
+        vmov s21, \val1
         \func \rptr, \bptr, \cptr, \zetaptr, \bufptr, \k, \q, \val0, \qqinv, \qqinv, \tmp, \tmp2, \tmp3, \val1, \ctr
-        vmov \bufptr, s2
-        vmov \q, s3
-        vmov \ctr, s4
-        vmov \val1, s5
+        vmov \bufptr, s18
+        vmov \q, s19
+        vmov \ctr, s20
+        vmov \val1, s21
 
         add ctr, #1
         
@@ -37,13 +37,13 @@
       cmp.w \k, #4
       bne.w 2f
         sub \cptr, #4*2
-        vmov s2, \bufptr
-        vmov s3, \q
-        vmov s4, \ctr
+        vmov s18, \bufptr
+        vmov s19, \q
+        vmov s20, \ctr
         \func \rptr, \bptr, \cptr, \zetaptr, \bufptr, \k, \q, \val0, \qqinv, \qqinv, \tmp, \tmp2, \tmp3, \val1, \ctr
-        vmov \bufptr, s2
-        vmov \q, s3
-        vmov \ctr, s4
+        vmov \bufptr, s18
+        vmov \q, s19
+        vmov \ctr, s20
 
         add \ctr, #1
         
@@ -57,7 +57,7 @@
 .endm
 
 .macro doublebasemul_asm_cache_16_32 rptr_tmp, aptr, bptr, zetaptr, poly0, poly1, poly2, poly3, q, qinv, tmp, tmp2, res, aprimeptr, zeta
-  vmov \aprimeptr, s11
+  vmov \aprimeptr, s27
   ldr \poly0, [\aptr], #4
   ldr \poly1, [\bptr]
   ldr \poly2, [\aptr], #4
@@ -89,11 +89,11 @@
   smuadx \tmp, \poly2, \poly3
   str.w \tmp, [\rptr_tmp, #4]
   str \tmp2, [\rptr_tmp], #8
-  vmov s11, \aprimeptr
+  vmov s27, \aprimeptr
 .endm 
 
 .macro doublebasemul_asm_acc_cache_32_32 rptr_tmp, aptr, bptr, zetaptr, poly0, poly1, poly2, poly3, q, qinv, tmp, tmp2, res, aprimeptr, zeta
-  vmov \aprimeptr, s11
+  vmov \aprimeptr, s27
   ldr \poly0, [\aptr], #4
   ldr \poly1, [\bptr]
   ldr \poly2, [\aptr], #4
@@ -129,11 +129,11 @@
   smladx \res, \poly2, \poly3, \res
 
   str \res, [\rptr_tmp], #4
-  vmov s11, \aprimeptr
+  vmov s27, \aprimeptr
 .endm
 
 .macro doublebasemul_asm_acc_cache_32_16 rptr_tmp, aptr, bptr, zetaptr, poly0, poly1, poly2, poly3, q, qinv, tmp, tmp2, res, aprimeptr, zeta
-  vmov \aprimeptr, s11
+  vmov \aprimeptr, s27
   ldr \poly0, [\aptr], #4
   ldr \poly1, [\bptr]
   ldr \poly2, [\aptr], #4
@@ -155,7 +155,7 @@
   montgomery \q, \qinv, \tmp, \poly0
   
   pkhtb \res, \poly0, \tmp2, asr#16
-  vmov \poly0, s12
+  vmov \poly0, s28
   str \res, [\poly0], #4
   
   neg \zeta, \zeta
@@ -177,8 +177,8 @@
 
   pkhtb \res, \tmp, \tmp2, asr#16
   str \res, [\poly0], #4
-  vmov s12, \poly0
-  vmov s11, \aprimeptr
+  vmov s28, \poly0
+  vmov s27, \aprimeptr
 .endm
 
 .macro load_vals val0, val1, bufptr, tmp
@@ -191,7 +191,7 @@
 .endm
 
 .macro doublebasemul_asm_opt_16_32 rptr_tmp, aptr, bptr, tmp3, poly0, poly1, poly2, poly3, q, qinv, tmp, tmp2, res, aprimeptr, tmp4
-  vmov \aprimeptr, s11
+  vmov \aprimeptr, s27
   ldr \poly0, [\aptr], #4
   ldr \poly1, [\bptr]
   ldr \poly2, [\aptr], #4
@@ -215,11 +215,11 @@
 
   str.w \tmp2, [\rptr_tmp], #4
   str.w \tmp3, [\rptr_tmp], #4
-  vmov s11, \aprimeptr
+  vmov s27, \aprimeptr
 .endm 
 
 .macro doublebasemul_asm_acc_opt_32_32 rptr_tmp, aptr, bptr, tmp3, poly0, poly1, poly2, poly3, q, qinv, tmp, tmp2, res, aprimeptr, tmp4
-  vmov \aprimeptr, s11
+  vmov \aprimeptr, s27
   ldr.w \poly0, [\aptr], #4
   ldr.w \poly1, [\bptr]
   ldr.w \poly2, [\aptr], #4
@@ -249,11 +249,11 @@
   str.w \tmp, [\rptr_tmp, #4]
   str \tmp4, [\rptr_tmp], #8
   
-  vmov s11, \aprimeptr
+  vmov s27, \aprimeptr
 .endm 
 
 .macro doublebasemul_asm_acc_opt_32_16 rptr_tmp, aptr, bptr, tmp3, poly0, poly1, poly2, poly3, q, qinv, tmp, tmp2, res, aprimeptr, tmp4
-  vmov \aprimeptr, s11
+  vmov \aprimeptr, s27
 
   ldr \poly0, [\aptr], #4
   ldr \poly1, [\bptr]
@@ -274,7 +274,7 @@
   montgomery \q, \qinv, \tmp, \tmp3
 
   pkhtb \res, \tmp3, \res, asr#16
-  vmov \poly0, s12
+  vmov \poly0, s28
   str \res, [\poly0], #4
     
   ldr \tmp2, [\aprimeptr], #4 // load cached value
@@ -291,6 +291,6 @@
 
   pkhtb \res, \tmp3, \res, asr#16
   str \res, [\poly0], #4
-  vmov s12, \poly0
-  vmov s11, \aprimeptr
+  vmov s28, \poly0
+  vmov s27, \aprimeptr
 .endm 

--- a/crypto_kem/kyber768/m4fspeed/matacc_asm.S
+++ b/crypto_kem/kyber768/m4fspeed/matacc_asm.S
@@ -17,7 +17,7 @@
     bge.w 2f
       vmov \bufptr, s17
 
-      vmov s0, r12
+      vmov s16, r12
       vmov s18, \rptr
       vmov s19, \bptr
       vmov s20, \cptr
@@ -29,7 +29,7 @@
 
       bl kyber_shake128_squeezeblocks
 
-      vmov r12, s0
+      vmov r12, s16
       vmov \rptr, s18
       vmov \bptr, s19
       vmov \cptr, s20

--- a/crypto_kem/kyber768/m4fspeed/matacc_asm.S
+++ b/crypto_kem/kyber768/m4fspeed/matacc_asm.S
@@ -8,31 +8,31 @@
 // kyber_shake128_squeezeblocks into buffer if all bytes have been used
 .macro third_if tmp, tmp2, rptr, bptr, cptr, bufptr, ctr
 // if (pos + 3 > buflen && ctr < KYBER_N/4)
-  vmov \tmp, s1
+  vmov \tmp, s17
   add \tmp, #168 // XOF_BLOCKBYTES=168
   add \tmp2, \bufptr, #3
   cmp.w \tmp2, \tmp  // pos + 3 > buflen
   ble.w 2f
     cmp.w \ctr, #256/4
     bge.w 2f
-      vmov \bufptr, s1
+      vmov \bufptr, s17
 
-      vmov s2, \rptr
-      vmov s3, \bptr
-      vmov s4, \cptr
-      vmov s5, \ctr
+      vmov s18, \rptr
+      vmov s19, \bptr
+      vmov s20, \cptr
+      vmov s21, \ctr
 
       mov \rptr, \bufptr
       movw \bptr, #1
-      vmov \cptr, s10 // load state
+      vmov \cptr, s26 // load state
 
       bl kyber_shake128_squeezeblocks
 
-      vmov \rptr, s2
-      vmov \bptr, s3
-      vmov \cptr, s4
-      vmov \ctr, s5
-      vmov \bufptr, s1
+      vmov \rptr, s18
+      vmov \bptr, s19
+      vmov \cptr, s20
+      vmov \ctr, s21
+      vmov \bufptr, s17
     2:
 .endm
 
@@ -62,17 +62,17 @@ matacc_asm_cache_16_32:
   
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #15*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -115,17 +115,17 @@ matacc_asm_cache_32_32:
   
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #15*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -169,13 +169,13 @@ matacc_asm_cache_32_16:
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
 
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #15*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
-  vmov s12, rptr // store "real" destinaton in FP
-  vmov s13, rptr // backup
+  vmov s28, rptr // store "real" destinaton in FP
+  vmov s29, rptr // backup
   ldr.w rptr, [sp, #16*4]
   
   movw q, #3329
@@ -183,7 +183,7 @@ matacc_asm_cache_32_16:
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
     load_vals val0, val1, bufptr, tmp
 
@@ -196,7 +196,7 @@ matacc_asm_cache_32_16:
     cmp ctr, #256/4
     blt.w 1b
 
-  vmov rptr, s13
+  vmov rptr, s29
 
   pop {r0-r11, pc}
 .size matacc_asm_cache_32_16, . - matacc_asm_cache_32_16
@@ -231,17 +231,17 @@ matacc_asm_opt_16_32:
   movt qqinv, #3327
   
   ldr.w tmp, [sp, #13*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #14*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -289,17 +289,17 @@ matacc_asm_opt_32_32:
   movt qqinv, #3327
   
   ldr.w tmp, [sp, #13*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #14*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -345,13 +345,13 @@ matacc_asm_opt_32_16:
   movt qqinv, #3327
   
   ldr.w tmp, [sp, #13*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   ldr.w tmp, [sp, #14*4] // load aprimeptr from stack
-  vmov s11, tmp
+  vmov s27, tmp
 
-  vmov s12, rptr // store "real" destinaton in FP
-  vmov s13, rptr // backup
+  vmov s28, rptr // store "real" destinaton in FP
+  vmov s29, rptr // backup
   ldr.w rptr, [sp, #15*4]
   
   movw q, #3329
@@ -359,7 +359,7 @@ matacc_asm_opt_32_16:
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     load_vals val0, val1, bufptr, tmp
@@ -373,7 +373,7 @@ matacc_asm_opt_32_16:
     cmp ctr, #256/4
     blt.w 1b
 
-  vmov rptr, s13
+  vmov rptr, s29
 
   pop {r0-r11, pc}
 .size matacc_asm_opt_32_16, . - matacc_asm_opt_32_16

--- a/crypto_kem/kyber768/m4fspeed/matacc_asm.S
+++ b/crypto_kem/kyber768/m4fspeed/matacc_asm.S
@@ -17,6 +17,7 @@
     bge.w 2f
       vmov \bufptr, s17
 
+      vmov s0, r12
       vmov s18, \rptr
       vmov s19, \bptr
       vmov s20, \cptr
@@ -28,6 +29,7 @@
 
       bl kyber_shake128_squeezeblocks
 
+      vmov r12, s0
       vmov \rptr, s18
       vmov \bptr, s19
       vmov \cptr, s20

--- a/crypto_kem/kyber768/m4fstack/matacc.h
+++ b/crypto_kem/kyber768/m4fstack/matacc.h
@@ -5,7 +5,22 @@
 #include "symmetric.h"
 
 extern void matacc_asm(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state);
+static inline void _matacc_asm(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s26");
+  matacc_asm(r, b, c, buf,_zetas, state);
+}
+#define matacc_asm _matacc_asm
+
 extern void matacc_asm_acc(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t zetas[64], xof_state *state);
+static inline void _matacc_asm_acc(int16_t *r, const int16_t *b, int16_t c[4], unsigned char buf[XOF_BLOCKBYTES+2], const int16_t _zetas[64], xof_state *state)
+{
+  // floating point registers clobbered by assembly function
+  asm volatile("" : : : "s16", "s17", "s18", "s19", "s20", "s21", "s26");
+  matacc_asm_acc(r, b, c, buf,_zetas, state);
+}
+#define matacc_asm_acc _matacc_asm_acc
 
 void matacc(poly* r, const polyvec *b, unsigned char i, const unsigned char *seed, int transposed);
 #endif

--- a/crypto_kem/kyber768/m4fstack/matacc.i
+++ b/crypto_kem/kyber768/m4fstack/matacc.i
@@ -75,6 +75,7 @@
     bge.w 2f
       vmov \bufptr, s17
 
+      vmov s0, r12
       vmov s18, \rptr
       vmov s19, \bptr
       vmov s20, \cptr
@@ -85,6 +86,7 @@
       vmov \cptr, s26 // load state
       bl kyber_shake128_squeezeblocks
       
+      vmov r12, s0
       vmov \rptr, s18
       vmov \bptr, s19
       vmov \cptr, s20

--- a/crypto_kem/kyber768/m4fstack/matacc.i
+++ b/crypto_kem/kyber768/m4fstack/matacc.i
@@ -22,15 +22,15 @@
         cmp.w \k, #4
         bne.w 2f
             sub \cptr, #4*2
-            vmov s2, \bufptr
-            vmov s3, \q
-            vmov s4, \ctr
-            vmov s5, \val1
+            vmov s18, \bufptr
+            vmov s19, \q
+            vmov s20, \ctr
+            vmov s21, \val1
             \func \rptr, \bptr, \cptr, \zetaptr, \bufptr, \k, \q, \val0, \qqinv, \qqinv, \tmp, \tmp2, \tmp3, \val1, \ctr
-            vmov \bufptr, s2
-            vmov \q, s3
-            vmov \ctr, s4
-            vmov \val1, s5
+            vmov \bufptr, s18
+            vmov \q, s19
+            vmov \ctr, s20
+            vmov \val1, s21
 
             add ctr, #1
             
@@ -50,13 +50,13 @@
             cmp.w \k, #4
             bne.w 2f
                 sub \cptr, #4*2
-                vmov s2, \bufptr
-                vmov s3, \q
-                vmov s4, \ctr
+                vmov s18, \bufptr
+                vmov s19, \q
+                vmov s20, \ctr
                 \func \rptr, \bptr, \cptr, \zetaptr, \bufptr, \k, \q, \val0, \qqinv, \qqinv, \tmp, \tmp2, \tmp3, \val1, \ctr
-                vmov \bufptr, s2
-                vmov \q, s3
-                vmov \ctr, s4
+                vmov \bufptr, s18
+                vmov \q, s19
+                vmov \ctr, s20
 
                 add \ctr, #1
                 
@@ -66,30 +66,30 @@
 
 .macro third_if tmp, tmp2, rptr, bptr, cptr, bufptr, ctr
 // if (pos + 3 > buflen && ctr < KYBER_N/4)
-  vmov \tmp, s1
+  vmov \tmp, s17
   add \tmp, #168 // XOF_BLOCKBYTES=168
   add \tmp2, \bufptr, #3
   cmp.w \tmp2, \tmp  // pos + 3 > buflen
   ble.w 2f
     cmp.w \ctr, #256/4
     bge.w 2f
-      vmov \bufptr, s1
+      vmov \bufptr, s17
 
-      vmov s2, \rptr
-      vmov s3, \bptr
-      vmov s4, \cptr
-      vmov s5, \ctr
+      vmov s18, \rptr
+      vmov s19, \bptr
+      vmov s20, \cptr
+      vmov s21, \ctr
 
       mov \rptr, \bufptr
       movw \bptr, #1
-      vmov \cptr, s10 // load state
+      vmov \cptr, s26 // load state
       bl kyber_shake128_squeezeblocks
       
-      vmov \rptr, s2
-      vmov \bptr, s3
-      vmov \cptr, s4
-      vmov \ctr, s5
-      vmov \bufptr, s1
+      vmov \rptr, s18
+      vmov \bptr, s19
+      vmov \cptr, s20
+      vmov \ctr, s21
+      vmov \bufptr, s17
     2:
 .endm
 

--- a/crypto_kem/kyber768/m4fstack/matacc.i
+++ b/crypto_kem/kyber768/m4fstack/matacc.i
@@ -75,7 +75,7 @@
     bge.w 2f
       vmov \bufptr, s17
 
-      vmov s0, r12
+      vmov s16, r12
       vmov s18, \rptr
       vmov s19, \bptr
       vmov s20, \cptr
@@ -86,7 +86,7 @@
       vmov \cptr, s26 // load state
       bl kyber_shake128_squeezeblocks
       
-      vmov r12, s0
+      vmov r12, s16
       vmov \rptr, s18
       vmov \bptr, s19
       vmov \cptr, s20

--- a/crypto_kem/kyber768/m4fstack/matacc_asm.S
+++ b/crypto_kem/kyber768/m4fstack/matacc_asm.S
@@ -31,14 +31,14 @@ matacc_asm:
   
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     ldrh val0, [bufptr], #2
@@ -86,14 +86,14 @@ matacc_asm_acc:
   
   ldr.w zetaptr, [sp, #13*4] // load zetaptr from stack
   ldr.w tmp, [sp, #14*4] // load state from stack
-  vmov s10, tmp
+  vmov s26, tmp
 
   movw q, #3329
   movw k, #0
 
   // outer while loop
   movw ctr, #0
-  vmov s1, bufptr // save bufptr to check later
+  vmov s17, bufptr // save bufptr to check later
   1:
 
     ldrh val0, [bufptr], #2


### PR DESCRIPTION
**in Kyber matacc assembly implementation:**

- changed floating-point registers from s(0-15) to s(16-31): registers from s0 to s15 can be overwritten by the called function
- changed s31 (s15) to s0 in kyberXXX-90s m4fspeed: floating point registers are usually saved in couples using the 64bit d registers
- instructed the C compiler to consider clobbered the used floating registers before calling the assembly code
- saved the r12 register before calling the C function in kyber m4fspeed matacc_asm.S and kyber m4fstack matacc.i