### PR TITLE
Github continuous integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+on: [push]
+jobs:
+  build-all:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Toolchain
+        uses: carlosperate/arm-none-eabi-gcc-action@v1.5.2
+        with:
+          release: 11.3.Rel1
+      - name: Build All
+        run: make PLATFORM=mps2-an386

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Install Toolchain
         uses: carlosperate/arm-none-eabi-gcc-action@v1.5.2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,9 @@
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [review_requested]
 jobs:
   build-all:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,12 +4,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install Toolchain
-        uses: carlosperate/arm-none-eabi-gcc-action@v1.5.2
+        uses: carlosperate/arm-none-eabi-gcc-action@v1.8.0
         with:
-          release: 11.3.Rel1
+          release: 13.2.Rel1
       - name: Build All
-        run: make PLATFORM=mps2-an386
+        run: make PLATFORM=mps2-an386 -j2

--- a/mk/mps2-an386.mk
+++ b/mk/mps2-an386.mk
@@ -21,6 +21,16 @@ CPPFLAGS += \
 LDFLAGS += \
 	--specs=nosys.specs \
 	-Wl,--wrap=_sbrk \
+	-Wl,--wrap=_open \
+	-Wl,--wrap=_close \
+	-Wl,--wrap=_isatty \
+	-Wl,--wrap=_kill \
+	-Wl,--wrap=_lseek \
+	-Wl,--wrap=_read \
+	-Wl,--wrap=_write \
+	-Wl,--wrap=_fstat \
+	-Wl,--wrap=_getpid \
+	-Wl,--no-warn-rwx-segments \
 	-ffreestanding \
 	-T$(LDSCRIPT) \
 	$(ARCH_FLAGS)


### PR DESCRIPTION
We could use the Github Actions to enable some minimal form of contiouus integration. The goal would be to build all schemes for the simulated platform, to at least ensure that everything builds.