### PR TITLE
Implement new stack measurement HAL API

### DIFF
--- a/common/hal-opencm3.c
+++ b/common/hal-opencm3.c
@@ -383,8 +383,41 @@ void* __wrap__sbrk (int incr)
 size_t hal_get_stack_size(void)
 {
   register char* cur_stack;
-	__asm__ volatile ("mov %0, sp" : "=r" (cur_stack));
+	asm volatile ("mov %0, sp" : "=r" (cur_stack));
   return cur_stack - heap_end;
+}
+
+const uint32_t stackpattern = 0xDEADBEEFlu;
+
+static void* last_sp = NULL;
+
+void hal_spraystack(void)
+{
+  
+  char* _heap_end = heap_end;
+  asm volatile ("mov %0, sp\n"
+                ".L%=:\n\t"
+                "str %2, [%1], #4\n\t"
+                "cmp %1, %0\n\t"
+                "blt .L%=\n\t"
+                : "+r" (last_sp), "+r" (_heap_end) : "r" (stackpattern) : "cc", "memory");
+}
+
+size_t hal_checkstack(void)
+{
+  size_t result = 0;
+  asm volatile("sub %0, %1, %2\n"
+               ".L%=:\n\t"
+               "ldr ip, [%2], #4\n\t"
+               "cmp ip, %3\n\t"
+               "ite eq\n\t"
+               "subeq %0, #4\n\t"
+               "bne .LE%=\n\t"
+               "cmp %2, %1\n\t"
+               "blt .L%=\n\t"
+               ".LE%=:\n"
+               : "+r"(result) : "r" (last_sp), "r" (heap_end), "r" (stackpattern) : "ip", "cc");
+  return result;
 }
 
 /* Implement some system calls to shut up the linker warnings */
@@ -392,6 +425,15 @@ size_t hal_get_stack_size(void)
 #include <errno.h>
 #undef errno
 extern int errno;
+
+int __wrap__open(char *file, int flags, int mode)
+{
+  (void) file;
+  (void) flags;
+  (void) mode;
+  errno = ENOSYS;
+  return -1;
+}
 
 int __wrap__close(int fd)
 {

--- a/common/test.c
+++ b/common/test.c
@@ -128,6 +128,14 @@ static void memory_timing_test(void)
 #define CLOCK_TEST CLOCK_BENCHMARK
 #endif
 
+void stacktest(size_t size)
+{
+  volatile uint32_t mem[size] __attribute__((unused));
+  for (unsigned i = 0; i < size; ++i) {
+    mem[i] = 0;
+  }
+}
+
 int main(void)
 {
   hal_setup(CLOCK_TEST);
@@ -136,6 +144,15 @@ int main(void)
   unsigned rnd;
   randombytes((unsigned char*) &rnd, sizeof(unsigned));
   send_unsigned("Random number", rnd);
+  size_t stack;
+  hal_spraystack();
+  stacktest(100);
+  stack = hal_checkstack();
+  send_unsigned("stackusage1", stack);
+  hal_spraystack();
+  stacktest(200);
+  stack = hal_checkstack();
+  send_unsigned("stackusage2", stack);
 #if defined(SRAM_TIMING_TEST)
   memory_timing_test();
 #endif


### PR DESCRIPTION
Use the new stack spraying/checking API of the HAL. This adds a small test in the `boardtest.elf`, which for me returns an accurate result (400/800 bytes alocated on stack, measurement returns 400/800 bytes). Some random spot-checks of schemes return very similar values for stack usage (few bytes difference, might also be explained by newer compiler).

The implementations checks entire words instead of bytes, so the result will only be on word granularity, i.e., 4 bytes.