### PR TITLE
Add PERK

### DIFF
--- a/skiplist.py
+++ b/skiplist.py
@@ -176,4 +176,12 @@ skip_list = [
     {'scheme': 'ov-Ip', 'implementation': 'ref', 'estmemory': 534528},
     {'scheme': 'ov-Ip-pkc', 'implementation': 'ref', 'estmemory': 568320},
     {'scheme': 'ov-Ip-pkc-skc', 'implementation': 'ref', 'estmemory': 330752},
+    {'scheme': 'perk-192-fast-3', 'implementation': 'ref', 'estmemory': 1036288},
+    {'scheme': 'perk-192-fast-5', 'implementation': 'ref', 'estmemory': 1001472},
+    {'scheme': 'perk-128-fast-5', 'implementation': 'ref', 'estmemory': 463872},
+    {'scheme': 'perk-256-fast-5', 'implementation': 'ref', 'estmemory': 1722368},
+    {'scheme': 'perk-128-fast-3', 'implementation': 'ref', 'estmemory': 475136},
+    {'scheme': 'perk-128-short-5', 'implementation': 'ref', 'estmemory': 2235392},
+    {'scheme': 'perk-256-fast-3', 'implementation': 'ref', 'estmemory': 1797120},
+    {'scheme': 'perk-128-short-3', 'implementation': 'ref', 'estmemory': 2377728},
 ]


### PR DESCRIPTION
https://github.com/mupq/pqm4/issues/284

This adds the implementations from https://pqc-perk.org/assets/downloads/perk_2023_05_31.zip.

perk-128-fast-{3,5} should be able to run on the 640 KB RAM board. The perk-{192,256}-short-* are out of reach even with 4 MB RAM in qemu, so I did not include those.
The remaining ones run in 4 MB RAM, but won't run on the board.

I have tested that testvectors, tests, benchmarks run fine on qemu and the nucleo-l476rg.

There is a newer package available at https://pqc-perk.org/assets/downloads/perk_2023_10_16.zip (with a change in testvectors), but that one relies on GMP....