### PR TITLE
Platform support for stm32f415

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -66,6 +66,7 @@ class M4Settings(mupq.PlatformSettings):
         'stm32f4discovery': 128*1024,
         'nucleo-l476rg': 128*1024,
         'cw308t-stm32f3': 64*1024,
+        'cw308t-stm32f415': 192*1024,
         'mps2-an386': 4096*1024,
         'nucleo-l4r5zi': 640*1024
     }


### PR DESCRIPTION
Update hal setup for stm32f415 and update interface.py platform_memory to handle stm32f415.
This should provide total support for stm32f415 as discussed in #258.