### PR TITLE
Update Kyber poly_tomsg to fix timing leak (w/ -Os)

### DIFF
--- a/crypto_kem/kyber512/m4fspeed/poly.c
+++ b/crypto_kem/kyber512/m4fspeed/poly.c
@@ -560,13 +560,18 @@ void poly_frommsg(poly *r, const unsigned char msg[KYBER_SYMBYTES]) {
 *              - const poly *a:      pointer to input polynomial
 **************************************************/
 void poly_tomsg(unsigned char msg[KYBER_SYMBYTES], poly *a) {
-    uint16_t t;
+    uint32_t t;
     int i, j;
 
     for (i = 0; i < KYBER_SYMBYTES; i++) {
         msg[i] = 0;
         for (j = 0; j < 8; j++) {
-            t = (((a->coeffs[8 * i + j] << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
+            t  = a->coeffs[8*i+j];
+            t <<= 1;
+            t += 1665;
+            t *= 80635;
+            t >>= 28;
+            t &= 1;
             msg[i] |= t << j;
         }
     }

--- a/crypto_kem/kyber512/m4fstack/poly.c
+++ b/crypto_kem/kyber512/m4fstack/poly.c
@@ -525,13 +525,18 @@ void poly_frommsg(poly *r, const unsigned char msg[KYBER_SYMBYTES]) {
 *              - const poly *a:      pointer to input polynomial
 **************************************************/
 void poly_tomsg(unsigned char msg[KYBER_SYMBYTES], poly *a) {
-    uint16_t t;
+    uint32_t t;
     int i, j;
 
     for (i = 0; i < KYBER_SYMBYTES; i++) {
         msg[i] = 0;
         for (j = 0; j < 8; j++) {
-            t = (((a->coeffs[8 * i + j] << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
+            t  = a->coeffs[8*i+j];
+            t <<= 1;
+            t += 1665;
+            t *= 80635;
+            t >>= 28;
+            t &= 1;
             msg[i] |= t << j;
         }
     }

--- a/crypto_kem/kyber768/m4fspeed/poly.c
+++ b/crypto_kem/kyber768/m4fspeed/poly.c
@@ -541,13 +541,18 @@ void poly_frommsg(poly *r, const unsigned char msg[KYBER_SYMBYTES]) {
 *              - const poly *a:      pointer to input polynomial
 **************************************************/
 void poly_tomsg(unsigned char msg[KYBER_SYMBYTES], poly *a) {
-    uint16_t t;
+    uint32_t t;
     int i, j;
 
     for (i = 0; i < KYBER_SYMBYTES; i++) {
         msg[i] = 0;
         for (j = 0; j < 8; j++) {
-            t = (((a->coeffs[8 * i + j] << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
+            t  = a->coeffs[8*i+j];
+            t <<= 1;
+            t += 1665;
+            t *= 80635;
+            t >>= 28;
+            t &= 1;
             msg[i] |= t << j;
         }
     }

--- a/crypto_kem/kyber768/m4fstack/poly.c
+++ b/crypto_kem/kyber768/m4fstack/poly.c
@@ -506,13 +506,18 @@ void poly_frommsg(poly *r, const unsigned char msg[KYBER_SYMBYTES]) {
 *              - const poly *a:      pointer to input polynomial
 **************************************************/
 void poly_tomsg(unsigned char msg[KYBER_SYMBYTES], poly *a) {
-    uint16_t t;
+    uint32_t t;
     int i, j;
 
     for (i = 0; i < KYBER_SYMBYTES; i++) {
         msg[i] = 0;
         for (j = 0; j < 8; j++) {
-            t = (((a->coeffs[8 * i + j] << 1) + KYBER_Q / 2) / KYBER_Q) & 1;
+            t  = a->coeffs[8*i+j];
+            t <<= 1;
+            t += 1665;
+            t *= 80635;
+            t >>= 28;
+            t &= 1;
             msg[i] |= t << j;
         }
     }


### PR DESCRIPTION
This (partially) addresses https://github.com/mupq/pqm4/issues/319.

The function poly_tomsg from the reference implementation of Kyber (which was copied into the M4-optimized implementations) would result in a variable-time udiv instruction operating on secret data when compiled with gcc using -Os. I tried a couple of versions from gcc 11 to gcc 13, but did not see any difference.

This commit updates the m4-specific code to use the patch from https://github.com/pq-crystals/kyber/commit/dda29cc63af721981ee2c831cf00822e69be3220. Note that the code in PQClean has not yet been updated and hence the clean implementation within pqm4 is still vulnerable.