### PR TITLE
Add AIMer

### DIFF
--- a/skiplist.py
+++ b/skiplist.py
@@ -275,4 +275,11 @@ skip_list = [
     {'scheme': 'snova-60-10-16-4-ssk', 'implementation': 'ref', 'estmemory': 1953792},
     {'scheme': 'snova-37-8-16-4-esk', 'implementation': 'ref', 'estmemory': 775168},
     {'scheme': 'snova-37-8-16-4-ssk', 'implementation': 'ref', 'estmemory': 646144},
+    {'scheme': 'aimer-l1-param2', 'implementation': 'ref', 'estmemory': 461824},
+    {'scheme': 'aimer-l1-param1', 'implementation': 'ref', 'estmemory': 206848},
+    {'scheme': 'aimer-l3-param1', 'implementation': 'ref', 'estmemory': 452608},
+    {'scheme': 'aimer-l5-param1', 'implementation': 'ref', 'estmemory': 926720},
+    {'scheme': 'aimer-l3-param2', 'implementation': 'ref', 'estmemory': 1091584},
+    {'scheme': 'aimer-l5-param2', 'implementation': 'ref', 'estmemory': 2169856},
+    {'scheme': 'aimer-l1-param3', 'implementation': 'ref', 'estmemory': 1442816},
 ]


### PR DESCRIPTION
🪣
Resolves https://github.com/mupq/pqm4/issues/261

This adds the AIMer implementations from the [NIST submission package](https://csrc.nist.gov/csrc/media/projects/pqc-dig-sig/documents/round-1/submission-pkg/AIMer-submission.zip).

There were a huge number of dynamic memory allocations that I eliminated and replaced by stack allocations. 
Unfortunatly that means that some parameter sets use a loooooot of stack - often more than the 8 MiB default stack on Linux. I excluded the parameter sets that exceed the 4 MiB available on the `mps2-an386`:
 - `aimer-l1-param4`
 - `aimer-l3-param3`
 - `aimer-l3-param4`
 - `aimer-l5-param3`
 - `aimer-l5-param4`
 
On `nucleo-l4r5zi` (640KB RAM), we can run 
  - `aimer-l1-param1`
  - `aimer-l1-param2`
  - `aimer-l3-param1`
  
  I successfully ran `test.py` and `testvectors.py` on both qemu and the `nucleo-l4r5zi`