### PR TITLE
Adds Apache-2.0 license in addition to CC0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 .PHONY: all
 all: tests tests-bin
 

--- a/README.md
+++ b/README.md
@@ -406,5 +406,6 @@ Each subdirectory containing implementations contains a LICENSE or COPYING file 
 under what license that specific implementation is released. 
 The files in common contain licensing information at the top of the file (and 
 are currently either public domain or MIT). 
-All other code in this repository is released under the conditions of [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+
+All other code in this repository is dual-licensed under [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) and under the conditions of [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
 

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 from mupq import mupq
 from interface import parse_arguments, get_platform
 import sys

--- a/build_everything.py
+++ b/build_everything.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 """
 Builds all of the binaries without flashing them.
 """

--- a/common/aes.c
+++ b/common/aes.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include <stdint.h>
 #include <string.h>
 #include "aes.h"

--- a/common/aes.h
+++ b/common/aes.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #ifndef AES_H
 #define AES_H
 

--- a/common/hal-mps2.c
+++ b/common/hal-mps2.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include <hal.h>
 #include <CMSDK_CM4.h>
 

--- a/common/hal-opencm3.c
+++ b/common/hal-opencm3.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "hal.h"
 #include <sys/cdefs.h>
 

--- a/common/keccaktest.c
+++ b/common/keccaktest.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "randombytes.h"
 #include <hal.h>
 #include <fips202.h>

--- a/common/randombytes.c
+++ b/common/randombytes.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include "randombytes.h"
 
 #if defined(STM32F2) || defined(STM32F4) || defined(STM32L4R5ZI) && !defined(MPS2_AN386)

--- a/common/test.c
+++ b/common/test.c
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 #include <hal.h>
 #include <randombytes.h>
 #include <sendfn.h>

--- a/convert_benchmarks.py
+++ b/convert_benchmarks.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 import sys
 from mupq import mupq
     

--- a/interface.py
+++ b/interface.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 import argparse
 
 from mupq import mupq

--- a/mk/config.mk
+++ b/mk/config.mk
@@ -1,2 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 CPPFLAGS += \
 	-DPQM4

--- a/mk/crypto.mk
+++ b/mk/crypto.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 SYMCRYPTO_SRC = \
 	mupq/common/fips202.c \
 	mupq/common/sp800-185.c \

--- a/mk/cw308t-stm32f3.mk
+++ b/mk/cw308t-stm32f3.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 DEVICE=stm32f303rct7
 OPENCM3_TARGET=lib/stm32/f3
 

--- a/mk/cw308t-stm32f415.mk
+++ b/mk/cw308t-stm32f415.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 DEVICE=stm32f415rgt6
 OPENCM3_TARGET=lib/stm32/f4
 

--- a/mk/mps2-an386.mk
+++ b/mk/mps2-an386.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 EXCLUDED_SCHEMES = \
 	mupq/crypto_sign/tuov_v/ref%
 

--- a/mk/nucleo-l476rg.mk
+++ b/mk/nucleo-l476rg.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 DEVICE=stm32l476rg
 OPENCM3_TARGET=lib/stm32/l4
 

--- a/mk/nucleo-l4r5zi.mk
+++ b/mk/nucleo-l4r5zi.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 DEVICE=stm32l4r5zi
 OPENCM3_TARGET=lib/stm32/l4
 

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 LIBHAL_SRC := \
 	common/hal-opencm3.c \
 	common/randombytes.c

--- a/mk/stm32f4discovery.mk
+++ b/mk/stm32f4discovery.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 DEVICE=stm32f407vg
 OPENCM3_TARGET=lib/stm32/f4
 

--- a/mk/tests.mk
+++ b/mk/tests.mk
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 ifeq ($(AIO),1)
 elf/boardtest.elf: common/test.c $(LINKDEPS) $(CONFIG)
 	$(compiletest)

--- a/st_nucleo_l4r5.cfg
+++ b/st_nucleo_l4r5.cfg
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
+
 # This is for STM32L4R5 Nucleo Dev Boards.
 source [find interface/stlink-dap.cfg]
 

--- a/test.py
+++ b/test.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 from mupq import mupq
 from interface import parse_arguments, get_platform
 

--- a/testvectors.py
+++ b/testvectors.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 or CC0-1.0
 from mupq import mupq
 from interface import parse_arguments, get_platform
 import sys


### PR DESCRIPTION
To enable re-use in https://github.com/pq-code-package/mlkem-c-embedded. This is applied only to the sources of pqm4 itself that are to a vast degree written by the pqm4 maintainers.
The scheme implementations plus symmetric primitives have other licenses.

@rpls, you wrote a lot of that code, could you please review if I got everything right?

@joostrijneveld, @Ko-, @cryptojedi: Parts of that code was written by you. Are you okay with dual licensing?