### PR TITLE
map to canonical

### DIFF
--- a/crypto_kem/ml-kem-512/m4fspeed/poly.c
+++ b/crypto_kem/ml-kem-512/m4fspeed/poly.c
@@ -367,6 +367,7 @@ void poly_tobytes(unsigned char *r, poly *a) {
     uint16_t t0, t1;
 
     poly_reduce(a);
+    poly_reduce(a);
 
     for (i = 0; i < KYBER_N / 2; i++) {
         t0 = a->coeffs[2 * i];

--- a/crypto_kem/ml-kem-512/m4fstack/poly.c
+++ b/crypto_kem/ml-kem-512/m4fstack/poly.c
@@ -367,6 +367,7 @@ void poly_tobytes(unsigned char *r, poly *a) {
     uint16_t t0, t1;
 
     poly_reduce(a);
+    poly_reduce(a);
 
     for (i = 0; i < KYBER_N / 2; i++) {
         t0 = a->coeffs[2 * i];

--- a/crypto_kem/ml-kem-768/m4fspeed/poly.c
+++ b/crypto_kem/ml-kem-768/m4fspeed/poly.c
@@ -142,7 +142,7 @@ void poly_packcompress(unsigned char *r, poly *a, int i) {
         d0 >>= 31;
         t[k] = d0 & 0x7ff;
       }
-      
+
 
     r[352*i+11*j+ 0] =  t[0] & 0xff;
     r[352*i+11*j+ 1] = (t[0] >>  8) | ((t[1] & 0x1f) << 3);
@@ -367,6 +367,7 @@ void poly_tobytes(unsigned char *r, poly *a) {
     uint16_t t0, t1;
 
     poly_reduce(a);
+    poly_reduce(a);
 
     for (i = 0; i < KYBER_N / 2; i++) {
         t0 = a->coeffs[2 * i];
@@ -465,7 +466,7 @@ void poly_noise(poly *r, const unsigned char *seed, unsigned char nonce, int add
 *              Using strategy of better accumulation (initial step).
 * Arguments:   - const poly *a:       pointer to input polynomial
 *              - const poly *b:       pointer to input polynomial
-*              - const poly *a_prime: pointer to a pre-multiplied by zetas 
+*              - const poly *a_prime: pointer to a pre-multiplied by zetas
 *              - int32_t *r_tmp:      array for accumulating unreduced results
 **************************************************/
 extern void basemul_asm_opt_16_32(int32_t *, const int16_t *, const int16_t *, const int16_t *);
@@ -481,7 +482,7 @@ void poly_basemul_opt_16_32(int32_t *r_tmp, const poly *a, const poly *b, const 
 *              Using strategy of better accumulation.
 * Arguments:   - const poly *a:       pointer to input polynomial
 *              - const poly *b:       pointer to input polynomial
-*              - const poly *a_prime: pointer to a pre-multiplied by zetas 
+*              - const poly *a_prime: pointer to a pre-multiplied by zetas
 *              - int32_t *r_tmp:      array for accumulating unreduced results
 **************************************************/
 extern void basemul_asm_acc_opt_32_32(int32_t *, const int16_t *, const int16_t *, const int16_t *);
@@ -497,7 +498,7 @@ void poly_basemul_acc_opt_32_32(int32_t *r_tmp, const poly *a, const poly *b, co
 *              Using strategy of better accumulation (final step).
 * Arguments:   - const poly *a:       pointer to input polynomial
 *              - const poly *b:       pointer to input polynomial
-*              - const poly *a_prime: pointer to a pre-multiplied by zetas 
+*              - const poly *a_prime: pointer to a pre-multiplied by zetas
 *              - poly *r:             pointer to output polynomial
 *              - int32_t *r_tmp:      array for accumulating unreduced results
 **************************************************/

--- a/crypto_kem/ml-kem-768/m4fstack/poly.c
+++ b/crypto_kem/ml-kem-768/m4fstack/poly.c
@@ -142,7 +142,7 @@ void poly_packcompress(unsigned char *r, poly *a, int i) {
         d0 >>= 31;
         t[k] = d0 & 0x7ff;
       }
-      
+
 
     r[352*i+11*j+ 0] =  t[0] & 0xff;
     r[352*i+11*j+ 1] = (t[0] >>  8) | ((t[1] & 0x1f) << 3);
@@ -366,6 +366,7 @@ void poly_tobytes(unsigned char *r, poly *a) {
     int i;
     uint16_t t0, t1;
 
+    poly_reduce(a);
     poly_reduce(a);
 
     for (i = 0; i < KYBER_N / 2; i++) {


### PR DESCRIPTION
This PR fixes the testvector mismatch introduced in https://github.com/mupq/pqm4/pull/244.

A bit more history.
In the PR https://github.com/mupq/pqm4/pull/128, there was the same issue. But this was identified and fixed before merging to pqm4. The problem is that the element 3329 should be mapped to 0 while packing to the public key array. In pull/128, there are two reductions: one in the NTT and one in the poly_tobytes. Due to the stack optimizations that are not described in the specification of Kyber/ML-KEM, the output of NTT should be mapped to [0, q) while packing the elements to the public key array. This remains until pull/244 removed the reduction in the NTT (and counted as a contribution of their paper). 

I encountered mismatched testvectors while generating with my own chacha20 for the randombytes and iterating with 5 iterations for all the parameter sets of ml-kem. The mismatched testvectors occurred only on the 5th iteration of ml-kem768.
I don't know what's the plan of the randombytes, so I only applied minimal changes to the files under crypto_kem.
Assembly optimized subroutines and detailed documentations will appear in the future.







- [ ] PR changes testvectors
- [ ] Tests pass in qemu
- [ ] Testvectors pass in qemu
- [ ] Tests pass on Nucleo-L4R5ZI 
- [ ] Testvectors pass on Nucleo-L4R5ZI 
- [ ] Updated Benchmarks
- [ ] Updated Skiplist entries
