### PR TITLE
Remove broken symlinks

### DIFF
--- a/crypto_kem/ml-kem-512/m4fspeed/symmetric-fips202.
+++ b/crypto_kem/ml-kem-512/m4fspeed/symmetric-fips202.
@@ -1,1 +1,0 @@
-../../ml-kem-768/m4fspeed/symmetric-fips202.

--- a/crypto_sign/ml-dsa-65/m4fstack/smalltt.h
+++ b/crypto_sign/ml-dsa-65/m4fstack/smalltt.h
@@ -1,1 +1,0 @@
-../../ml-dsa-44/m4fstack/smalltt.h


### PR DESCRIPTION
Fixes #370.
Found with `find . -xtype l`
