### PR TITLE
mlkem-native v1.0.0 integration

### DIFF
--- a/benchmarks.csv
+++ b/benchmarks.csv
@@ -11,12 +11,15 @@ hqc-256 (10 executions),clean,295934078,295934057,295934104,591853870,591853850,
 ml-kem-1024 (10 executions),clean,1536343,1535750,1536698,1708071,1707476,1708427,2020327,2019721,2020672
 ml-kem-1024 (10 executions),m4fspeed,1018976,1014877,1026934,1031565,1027454,1039544,1094008,1089897,1101987
 ml-kem-1024 (10 executions),m4fstack,1020202,1017478,1029553,1037953,1035260,1047298,1100982,1098251,1110327
+ml-kem-1024 (100 executions),mlkem-native,1199669,1193125,1237955,1331376,1324853,1369669,1601677,1595153,1640008
 ml-kem-512 (10 executions),clean,595793,595576,595971,700605,700383,700779,888653,888436,888831
 ml-kem-512 (10 executions),m4fspeed,392423,392211,392614,390881,390671,391073,428167,427955,428357
 ml-kem-512 (10 executions),m4fstack,392224,391772,392541,392864,392407,393181,430202,429745,430519
+ml-kem-512 (100 executions),mlkem-native,489033,486884,531269,585802,583656,628026,747256,745108,789479
 ml-kem-768 (10 executions),clean,988722,985880,998135,1138225,1135419,1147634,1387984,1385144,1397397
 ml-kem-768 (10 executions),m4fspeed,642096,639116,651103,658754,655785,667769,707827,704858,716842
 ml-kem-768 (10 executions),m4fstack,644195,640433,652374,664654,660893,672834,714194,710433,722374
+ml-kem-768 (100 executions),mlkem-native,805317,802419,847120,905221,902328,947006,1119531,1116638,1161316
 Signature Schemes,,,,,,,,,,
 Scheme,Implementation,Key Generation [cycles] (mean),Key Generation [cycles] (min),Key Generation [cycles] (max),Sign [cycles] (mean),Sign [cycles] (min),Sign [cycles] (max),Verify [cycles] (mean),Verify [cycles] (min),Verify [cycles] (max)
 aimer128f (10 executions),m4speed,490087,490087,490088,28590420,28590395,28590439,26750578,26749771,26751014
@@ -154,12 +157,15 @@ hqc-256,clean,103756,161508,175972,,,,,,
 ml-kem-1024,clean,15128,18776,20352,,,,,,
 ml-kem-1024,m4fspeed,6436,7500,7484,,,,,,
 ml-kem-1024,m4fstack,3332,3372,3356,,,,,,
+ml-kem-1024,mlkem-native,18688,22368,23904,,,,,,
 ml-kem-512,clean,6152,8784,9560,,,,,,
 ml-kem-512,m4fspeed,4372,5436,5412,,,,,,
 ml-kem-512,m4fstack,2300,2348,2332,,,,,,
+ml-kem-512,mlkem-native,8952,11608,12344,,,,,,
 ml-kem-768,clean,10248,13384,14480,,,,,,
 ml-kem-768,m4fspeed,5396,6468,6452,,,,,,
 ml-kem-768,m4fstack,2820,2860,2844,,,,,,
+ml-kem-768,mlkem-native,13624,16784,17840,,,,,,
 Signature Schemes,,,,,,,,,,
 Scheme,Implementation,Key Generation [bytes],Sign [bytes],Verify [bytes],,,,,,
 aimer128f,m4speed,8720,123376,15448,,,,,,
@@ -298,12 +304,15 @@ hqc-256,clean,0.2,0.4,0.3,,,,,,
 ml-kem-1024,clean,50.0,45.7,38.6,,,,,,
 ml-kem-1024,m4fspeed,75.3,75.5,71.2,,,,,,
 ml-kem-1024,m4fstack,75.1,74.9,70.7,,,,,,
+ml-kem-1024,mlkem-native,64.4,58.9,57.1,,,,,,
 ml-kem-512,clean,49.8,41.1,32.5,,,,,,
 ml-kem-512,m4fspeed,75.5,73.5,67.1,,,,,,
 ml-kem-512,m4fstack,75.6,73.2,66.9,,,,,,
+ml-kem-512,mlkem-native,61.0,52.9,50.3,,,,,,
 ml-kem-768,clean,48.5,43.2,35.4,,,,,,
 ml-kem-768,m4fspeed,74.5,74.4,69.2,,,,,,
 ml-kem-768,m4fstack,74.4,73.9,68.7,,,,,,
+ml-kem-768,mlkem-native,62.5,55.7,53.8,,,,,,
 Signature Schemes,,,,,,,,,,
 Scheme,Implementation,Key Generation [%],Sign [%],Verify [%],,,,,,
 aimer128f,m4speed,57.9,49.5,50.1,,,,,,
@@ -441,12 +450,15 @@ hqc-256,clean,26260,0,0,26260,,,,,
 ml-kem-1024,clean,6160,0,0,6160,,,,,
 ml-kem-1024,m4fspeed,16916,0,0,16916,,,,,
 ml-kem-1024,m4fstack,14016,0,0,14016,,,,,
+ml-kem-1024,mlkem-native,7444,0,0,7444,,,,,
 ml-kem-512,clean,5116,0,0,5116,,,,,
 ml-kem-512,m4fspeed,15848,0,0,15848,,,,,
 ml-kem-512,m4fstack,13328,0,0,13328,,,,,
+ml-kem-512,mlkem-native,6964,0,0,6964,,,,,
 ml-kem-768,clean,5120,0,0,5120,,,,,
 ml-kem-768,m4fspeed,16016,0,0,16016,,,,,
 ml-kem-768,m4fstack,13320,0,0,13320,,,,,
+ml-kem-768,mlkem-native,6568,0,0,6568,,,,,
 Signature Schemes,,,,,,,,,,
 Scheme,Implementation,.text [bytes],.data [bytes],.bss [bytes],Total [bytes],,,,,
 aimer128f,m4speed,15992,0,0,15992,,,,,

--- a/benchmarks.md
+++ b/benchmarks.md
@@ -12,12 +12,15 @@
 | ml-kem-1024 (10 executions) | clean | AVG: 1,536,343 <br /> MIN: 1,535,750 <br /> MAX: 1,536,698 | AVG: 1,708,071 <br /> MIN: 1,707,476 <br /> MAX: 1,708,427 | AVG: 2,020,327 <br /> MIN: 2,019,721 <br /> MAX: 2,020,672 |
 | ml-kem-1024 (10 executions) | m4fspeed | AVG: 1,018,976 <br /> MIN: 1,014,877 <br /> MAX: 1,026,934 | AVG: 1,031,565 <br /> MIN: 1,027,454 <br /> MAX: 1,039,544 | AVG: 1,094,008 <br /> MIN: 1,089,897 <br /> MAX: 1,101,987 |
 | ml-kem-1024 (10 executions) | m4fstack | AVG: 1,020,202 <br /> MIN: 1,017,478 <br /> MAX: 1,029,553 | AVG: 1,037,953 <br /> MIN: 1,035,260 <br /> MAX: 1,047,298 | AVG: 1,100,982 <br /> MIN: 1,098,251 <br /> MAX: 1,110,327 |
+| ml-kem-1024 (100 executions) | mlkem-native | AVG: 1,199,669 <br /> MIN: 1,193,125 <br /> MAX: 1,237,955 | AVG: 1,331,376 <br /> MIN: 1,324,853 <br /> MAX: 1,369,669 | AVG: 1,601,677 <br /> MIN: 1,595,153 <br /> MAX: 1,640,008 |
 | ml-kem-512 (10 executions) | clean | AVG: 595,793 <br /> MIN: 595,576 <br /> MAX: 595,971 | AVG: 700,605 <br /> MIN: 700,383 <br /> MAX: 700,779 | AVG: 888,653 <br /> MIN: 888,436 <br /> MAX: 888,831 |
 | ml-kem-512 (10 executions) | m4fspeed | AVG: 392,423 <br /> MIN: 392,211 <br /> MAX: 392,614 | AVG: 390,881 <br /> MIN: 390,671 <br /> MAX: 391,073 | AVG: 428,167 <br /> MIN: 427,955 <br /> MAX: 428,357 |
 | ml-kem-512 (10 executions) | m4fstack | AVG: 392,224 <br /> MIN: 391,772 <br /> MAX: 392,541 | AVG: 392,864 <br /> MIN: 392,407 <br /> MAX: 393,181 | AVG: 430,202 <br /> MIN: 429,745 <br /> MAX: 430,519 |
+| ml-kem-512 (100 executions) | mlkem-native | AVG: 489,033 <br /> MIN: 486,884 <br /> MAX: 531,269 | AVG: 585,802 <br /> MIN: 583,656 <br /> MAX: 628,026 | AVG: 747,256 <br /> MIN: 745,108 <br /> MAX: 789,479 |
 | ml-kem-768 (10 executions) | clean | AVG: 988,722 <br /> MIN: 985,880 <br /> MAX: 998,135 | AVG: 1,138,225 <br /> MIN: 1,135,419 <br /> MAX: 1,147,634 | AVG: 1,387,984 <br /> MIN: 1,385,144 <br /> MAX: 1,397,397 |
 | ml-kem-768 (10 executions) | m4fspeed | AVG: 642,096 <br /> MIN: 639,116 <br /> MAX: 651,103 | AVG: 658,754 <br /> MIN: 655,785 <br /> MAX: 667,769 | AVG: 707,827 <br /> MIN: 704,858 <br /> MAX: 716,842 |
 | ml-kem-768 (10 executions) | m4fstack | AVG: 644,195 <br /> MIN: 640,433 <br /> MAX: 652,374 | AVG: 664,654 <br /> MIN: 660,893 <br /> MAX: 672,834 | AVG: 714,194 <br /> MIN: 710,433 <br /> MAX: 722,374 |
+| ml-kem-768 (100 executions) | mlkem-native | AVG: 805,317 <br /> MIN: 802,419 <br /> MAX: 847,120 | AVG: 905,221 <br /> MIN: 902,328 <br /> MAX: 947,006 | AVG: 1,119,531 <br /> MIN: 1,116,638 <br /> MAX: 1,161,316 |
 ## Signature Schemes
 | scheme | implementation | key generation [cycles] | sign [cycles] | verify [cycles] |
 | ------ | -------------- | ----------------------- | ------------- | --------------- |
@@ -157,12 +160,15 @@
 | ml-kem-1024 | clean | 15,128 | 18,776 | 20,352 |
 | ml-kem-1024 | m4fspeed | 6,436 | 7,500 | 7,484 |
 | ml-kem-1024 | m4fstack | 3,332 | 3,372 | 3,356 |
+| ml-kem-1024 | mlkem-native | 18,688 | 22,368 | 23,904 |
 | ml-kem-512 | clean | 6,152 | 8,784 | 9,560 |
 | ml-kem-512 | m4fspeed | 4,372 | 5,436 | 5,412 |
 | ml-kem-512 | m4fstack | 2,300 | 2,348 | 2,332 |
+| ml-kem-512 | mlkem-native | 8,952 | 11,608 | 12,344 |
 | ml-kem-768 | clean | 10,248 | 13,384 | 14,480 |
 | ml-kem-768 | m4fspeed | 5,396 | 6,468 | 6,452 |
 | ml-kem-768 | m4fstack | 2,820 | 2,860 | 2,844 |
+| ml-kem-768 | mlkem-native | 13,624 | 16,784 | 17,840 |
 ## Signature Schemes
 | Scheme | Implementation | Key Generation [bytes] | Sign [bytes] | Verify [bytes] |
 | ------ | -------------- | ---------------------- | ------------ | -------------- |
@@ -302,12 +308,15 @@
 | ml-kem-1024 | clean | 50.0% | 45.7% | 38.6% |
 | ml-kem-1024 | m4fspeed | 75.3% | 75.5% | 71.2% |
 | ml-kem-1024 | m4fstack | 75.1% | 74.9% | 70.7% |
+| ml-kem-1024 | mlkem-native | 64.4% | 58.9% | 57.1% |
 | ml-kem-512 | clean | 49.8% | 41.1% | 32.5% |
 | ml-kem-512 | m4fspeed | 75.5% | 73.5% | 67.1% |
 | ml-kem-512 | m4fstack | 75.6% | 73.2% | 66.9% |
+| ml-kem-512 | mlkem-native | 61.0% | 52.9% | 50.3% |
 | ml-kem-768 | clean | 48.5% | 43.2% | 35.4% |
 | ml-kem-768 | m4fspeed | 74.5% | 74.4% | 69.2% |
 | ml-kem-768 | m4fstack | 74.4% | 73.9% | 68.7% |
+| ml-kem-768 | mlkem-native | 62.5% | 55.7% | 53.8% |
 ## Signature Schemes
 | Scheme | Implementation | Key Generation [%] | Sign [%] | Verify [%] |
 | ------ | -------------- | ------------------ | -------- | ---------- |
@@ -447,12 +456,15 @@
 | ml-kem-1024 | clean | 6,160 | 0 | 0 | 6,160 |
 | ml-kem-1024 | m4fspeed | 16,916 | 0 | 0 | 16,916 |
 | ml-kem-1024 | m4fstack | 14,016 | 0 | 0 | 14,016 |
+| ml-kem-1024 | mlkem-native | 7,444 | 0 | 0 | 7,444 |
 | ml-kem-512 | clean | 5,116 | 0 | 0 | 5,116 |
 | ml-kem-512 | m4fspeed | 15,848 | 0 | 0 | 15,848 |
 | ml-kem-512 | m4fstack | 13,328 | 0 | 0 | 13,328 |
+| ml-kem-512 | mlkem-native | 6,964 | 0 | 0 | 6,964 |
 | ml-kem-768 | clean | 5,120 | 0 | 0 | 5,120 |
 | ml-kem-768 | m4fspeed | 16,016 | 0 | 0 | 16,016 |
 | ml-kem-768 | m4fstack | 13,320 | 0 | 0 | 13,320 |
+| ml-kem-768 | mlkem-native | 6,568 | 0 | 0 | 6,568 |
 ## Signature Schemes
 | Scheme | Implementation | .text [bytes] | .data [bytes] | .bss [bytes] | Total [bytes] |
 | ------ | -------------- | ------------- | ------------- | ------------ | ------------- |

--- a/skiplist.py
+++ b/skiplist.py
@@ -218,4 +218,7 @@ skip_list = [
     {'scheme': 'ov-Ip', 'implementation': 'ref', 'estmemory': 537600},
     {'scheme': 'ov-Ip-pkc', 'implementation': 'ref', 'estmemory': 567296},
     {'scheme': 'ov-Ip-pkc-skc', 'implementation': 'ref', 'estmemory': 329728},
+    {'scheme': 'ml-kem-512', 'implementation': 'mlkem-native', 'estmemory': 16384},
+    {'scheme': 'ml-kem-768', 'implementation': 'mlkem-native', 'estmemory': 23552},
+    {'scheme': 'ml-kem-1024', 'implementation': 'mlkem-native', 'estmemory': 31744},
 ]


### PR DESCRIPTION
mlkem-native](https://github.com/pq-code-package/mlkem-native) v1.0.0 was released yesterday. 

[mlkem-native](https://github.com/pq-code-package/mlkem-native) isn't specifically targeting embeded systems (yet), but possibly it's still interesting for some embedded systems. This may be interesting for some consumers looking for a well-maintained FIPS203-compliant alternative to the reference implementation/PQClean. It should be a little faster than the reference implementation. Integration is straightforward as this PR shows. 

This PR adds mlkem-native into mupq and adds it to pqm4.

- [x] Tests pass in qemu
- [x] Testvectors pass in qemu
- [x] Tests pass on Nucleo-L4R5ZI 
- [x] Testvectors pass on Nucleo-L4R5ZI 
- [x] Updated Benchmarks
- [x] Updated Skiplist entries
