### PR TITLE
Add -fbuiltin flag to Makefiles

### DIFF
--- a/mk/mps2-an386.mk
+++ b/mk/mps2-an386.mk
@@ -36,6 +36,7 @@ LDFLAGS += \
 	-Wl,--wrap=_getpid \
 	-Wl,--no-warn-rwx-segments \
 	-ffreestanding \
+	-fbuiltin \
 	-T$(LDSCRIPT) \
 	$(ARCH_FLAGS)
 

--- a/mk/opencm3.mk
+++ b/mk/opencm3.mk
@@ -100,6 +100,7 @@ LDFLAGS += \
 	-Wl,--wrap=_getpid \
 	-nostartfiles \
 	-ffreestanding \
+	-fbuiltin \
 	-T$(LDSCRIPT) \
 	$(ARCH_FLAGS)
 


### PR DESCRIPTION
- [ ] PR changes testvectors
- [ ] Tests pass in qemu
- [ ] Testvectors pass in qemu
- [ ] Tests pass on Nucleo-L4R5ZI 
- [ ] Testvectors pass on Nucleo-L4R5ZI 
- [ ] Updated Benchmarks
- [ ] Updated Skiplist entries

Closes #402. Let me know which tests you'd like me to run --  the full suite takes a very long time and I can't block my only Nucleo-L4R5ZI board for too long.