### PR TITLE
ML-KEM bugfix: Fix symlink to fastinvntt.S

### DIFF
--- a/crypto_kem/ml-kem-1024/m4fstack/fastinvntt.S
+++ b/crypto_kem/ml-kem-1024/m4fstack/fastinvntt.S
@@ -1,1 +1,1 @@
-../../ml-kem-768/m4fspeed/fastinvntt.S
+../../ml-kem-768/m4fstack/fastinvntt.S


### PR DESCRIPTION
I was trying to benchmark `ml-kem-1024/m4fstack` and I kept running into correctness issues. Turns out that it uses `m4fspeed/fastinvntt.S` instead of `m4fstack/fastinvntt.S`. This is an important difference because they do differing amounts of reductions. This causes a correctness error some of the time. The following script produces `ERROR KEYS` 4 times out of the total 500 iterations:

```bash
rm -f elf/crypto_kem_ml-kem-1024_m4fstack_speed.elf
make PLATFORM=mps2-an386 MUPQ_ITERATIONS=500 \
    IMPLEMENTATION_PATH=crypto_kem/ml-kem-1024/m4fstack \
    elf/crypto_kem_ml-kem-1024_m4fstack_speed.elf
qemu-system-arm -M mps2-an386 -nographic -semihosting -kernel elf/crypto_kem_ml-kem-1024_m4fstack_speed.elf \
    | grep -B6 ERROR
```

The fix is to just link to the correct file